### PR TITLE
ci/use pypi token

### DIFF
--- a/.ci/azure-publish-dist.yml
+++ b/.ci/azure-publish-dist.yml
@@ -11,6 +11,6 @@ steps:
 - script: |
     python -m pip install -r requirements_build.txt
     python -m pip install twine
-    python -m twine upload dist/* --skip-existing -p $(TWINE_PASSWORD) -u $(TWINE_USERNAME)
+    python -m twine upload dist/* --skip-existing -p $(PYPI_TOKEN) -u __token__
   displayName: 'Upload Artifacts'
   condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')

--- a/.ci/build_documentation.yml
+++ b/.ci/build_documentation.yml
@@ -35,16 +35,15 @@ steps:
 
 - script: |
     cd ..
-    git clone --single-branch --branch gh-pages https://$(github_pat)@github.com/pyansys/pymapdl-reader.git gh_pages
+    git clone --no-checkout https://$(github_pat)@github.com/pyansys/pymapdl-reader.git gh_pages
     cd gh_pages
-    git gc --prune=now
-    git remote prune origin
-    git config user.email $(gh_email)
+    git checkout --orphan gh_pages
     git config user.name $(gh_user)
-    rm -rf *
+    git config user.email $(gh_email)
     cp -r $BUILD_SOURCESDIRECTORY/docs/build/html/* .
     touch .nojekyll
     git add .
     git commit -am "Pipelines-Bot: Updated site via $(Build.SourceVersion)"
-    git push
+    git push -u origin gh_pages -f
   displayName: Push to gh-pages
+  # condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/.ci/build_documentation.yml
+++ b/.ci/build_documentation.yml
@@ -48,4 +48,3 @@ steps:
     git commit -am "Pipelines-Bot: Updated site via $(Build.SourceVersion)"
     git push
   displayName: Push to gh-pages
-  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/.ci/build_documentation.yml
+++ b/.ci/build_documentation.yml
@@ -38,6 +38,7 @@ steps:
     git clone --no-checkout https://$(github_pat)@github.com/pyansys/pymapdl-reader.git gh_pages
     cd gh_pages
     git checkout --orphan gh_pages
+    rm -rf *
     git config user.name $(gh_user)
     git config user.email $(gh_email)
     cp -r $BUILD_SOURCESDIRECTORY/docs/build/html/* .
@@ -46,4 +47,4 @@ steps:
     git commit -am "Pipelines-Bot: Updated site via $(Build.SourceVersion)"
     git push -u origin gh_pages -f
   displayName: Push to gh-pages
-  # condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-reader module."""
 
 # major, minor, patch
-version_info = 0, 50, 0
+version_info = 0, 50, 1
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-reader module."""
 
 # major, minor, patch
-version_info = 0, 50, 1
+version_info = 0, 50, 0
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
This PR updates the doc-build step to push the documentation in an orphaned branch to github to rewirte the history of `gh-pages` to remove history.  Since the ``master`` branch is protected now, there's no change that the main branch can be affected by a potential force push.
