### PR TITLE
Add Overwrite Solution Records

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@ a useful tool for all users.  As such, we welcome and encourage any
 questions or submissions to this repository.
 
 For the full contributing documentation, please visit [PyMAPDL-Reader
-Contributing Guid](https:://readerdocs.pyansys.com/contributing.html)
+Contributing Guide](https://readerdocs.pyansys.com/contributing.html)

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,13 @@
 ======================================================
 PyMAPDL Reader - Legacy Binary and Archive File Reader
 ======================================================
+.. image:: https://badge.fury.io/py/ansys-mapdl-reader.svg
+    :target: https://badge.fury.io/py/ansys-mapdl-reader
+
+.. image:: https://dev.azure.com/pyansys/pyansys/_apis/build/status/pyansys.pymapdl-reader?branchName=master
+    :target: https://dev.azure.com/pyansys/pyansys/_build/latest?definitionId=4&branchName=master
+
+
 This is the legacy module for reading in binary and ASCII files
 generated from MAPDL.
 
@@ -13,7 +20,7 @@ The ``ansys-mapdl-reader`` module supports the following formats:
 
   - ``*.rst`` - Structural analysis result file
   - ``*.rth`` - Thermal analysis result file 
-  - ``*.emat`` - Element matrice data file
+  - ``*.emat`` - Element matrix data file
   - ``*.full`` - Full stiffness-mass matrix file
   - ``*.cdb`` or ``*.dat`` - MAPDL ASCII block archive and
     Mechanical Workbench input files

--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-reader module."""
 
 # major, minor, patch
-version_info = 0, 50, 0
+version_info = 0, 50, 1
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/reader/common.py
+++ b/ansys/mapdl/reader/common.py
@@ -184,6 +184,7 @@ def read_table(f, dtype='i', nread=None, skip=False, get_nread=True, cython=Fals
 
     if get_nread:
         n = np.fromfile(f, 'i', 1)
+        print(n)
         if not n:
             raise Exception('end of file')
 

--- a/ansys/mapdl/reader/cython/binary_reader.cpp
+++ b/ansys/mapdl/reader/cython/binary_reader.cpp
@@ -57,6 +57,13 @@ int read_header(ifstream* binFile, int* bsparse_flag, int* wsparse_flag,
   *prec_flag = (raw[7] >> 6) & 1;
   *type_flag = (raw[7] >> 7) & 1;
 
+  // cout << "bufsize" << bufsize << "\n";
+  // cout << "bsparse_flag" << *bsparse_flag << "\n";
+  // cout << "wsparse_flag" << *wsparse_flag << "\n";
+  // cout << "zlib_flag" << *zlib_flag << "\n";
+  // cout << "prec_flag" << *prec_flag << "\n";
+  // cout << "type_flag" << *type_flag << "\n";
+
   delete[] raw;
   return bufsize;
 }
@@ -423,7 +430,6 @@ void* read_record(const char* filename, int64_t ptr, int* prec_flag, int* type_f
     }
     
   }
-  
 
   return raw;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,10 @@ pygments_style = 'sphinx'
 todo_include_todos = False
 
 
+# Copy button customization ---------------------------------------------------
+# exclude traditional Python prompts from the copied code
+copybutton_prompt_text = ">>> "
+
 
 # -- Sphinx Gallery Options
 from sphinx_gallery.sorting import FileNameSortKey


### PR DESCRIPTION
This PR adds a solution overwrite method.  For example:

```python
Overwrite the elastic strain record for element 1 for the
first result with random data.

>>> from ansys.mapdl import reader as pymapdl_reader
>>> rst = pymapdl_reader.read_binary('file.rst')
>>> data = np.random.random(56)
>>> rst.overwrite_element_solution_data(data, 0, 'EEL', 1)
```

This approach has a few limitations:

First, it will not work on compressed records.  Most non-zero solution results are non-zero, so this should work.  However, if some records are compressed, data compression will have to be disabled.  See the documentation for more details.

Second, it's not optimized.  Records are overwritten one element at a time.  This could be made more efficient, especially given a large array of contiguous results, or a list of arrays.  Part of the issue is the result file is opened and closed for each result.  This was a design choice to avoid caching an open file.  This can be patched for performance considerations.
