### PR TITLE
Faster Archive Writer

### DIFF
--- a/.ci/install_package.yml
+++ b/.ci/install_package.yml
@@ -1,0 +1,5 @@
+steps:
+- script: |
+    python -m pip install -r requirements.txt
+    python -m pip install $(package_name) -f dist/ --no-index
+  displayName: 'Install ansys-mapdl-reader'

--- a/.ci/install_pyansys.yml
+++ b/.ci/install_pyansys.yml
@@ -1,6 +1,0 @@
-steps:
-- script: |
-    cd dist
-    python -m pip install $(package_name) -f .
-    cd ..
-  displayName: 'Install pyansys'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include ansys/mapdl/reader/cython/*.h

--- a/ansys/mapdl/reader/__init__.py
+++ b/ansys/mapdl/reader/__init__.py
@@ -11,6 +11,7 @@ from ansys.mapdl.reader.cell_quality import quality
 from ansys.mapdl.reader.common import read_binary
 from ansys.mapdl.reader.misc import Report, _configure_pyvista
 from ansys.mapdl.reader import examples
+from . import _archive
 
 # Setup data directory
 try:

--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -483,6 +483,8 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
     with open(str(filename), mode) as f:
         f.write(header)
 
+    if not isinstance(filename, str):
+        filename = str(filename)
     write_nblock(filename, nodenum, grid.points, mode='a')
 
     # write remainder of eblock

--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -12,7 +12,7 @@ from vtk import (VTK_TETRA, VTK_QUADRATIC_TETRA, VTK_PYRAMID,
 import vtk
 import pyvista as pv
 
-from ansys.mapdl.reader import _reader
+from ansys.mapdl.reader import _reader, _archive
 from ansys.mapdl.reader.misc import vtk_cell_info, chunks
 from ansys.mapdl.reader.mesh import Mesh
 from ansys.mapdl.reader.cell_quality import quality
@@ -346,7 +346,7 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
     else:
         log.info('No ANSYS node numbers set in input.  ' +
                  'Adding default range')
-        nodenum = np.arange(1, grid.number_of_points + 1)
+        nodenum = np.arange(1, grid.number_of_points + 1, dtype=np.int32)
 
     if np.any(nodenum == -1):
         if not allow_missing:
@@ -358,7 +358,7 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
         end_num = start_num + nadd
         log.info('FEM missing some node numbers.  Adding node numbering ' +
                  'from %d to %d' % (start_num, end_num))
-        nodenum[nodenum == -1] = np.arange(start_num, end_num)
+        nodenum[nodenum == -1] = np.arange(start_num, end_num, dtype=np.int32)
 
     # element block
     ncells = grid.number_of_cells
@@ -369,29 +369,29 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
             raise Exception('Missing node numbers.  Exiting due "allow_missing=False"')
         log.info('No ANSYS element numbers set in input.  ' +
                  'Adding default range starting from %d' % enum_start)
-        enum = np.arange(1, ncells + 1)
+        enum = np.arange(1, ncells + 1, dtype=np.int32)
 
     if np.any(enum == -1):
         if not allow_missing:
             raise Exception('-1 encountered in "ansys_elem_num".\n'
-                            + 'Exiting due "allow_missing=False"')
+                            'Exiting due "allow_missing=False"')
 
         start_num = enum.max() + 1
         if enum_start > start_num:
-           start_num = enum_start
+            start_num = enum_start
         nadd = np.sum(enum == -1)
         end_num = start_num + nadd
         log.info('FEM missing some cell numbers.  Adding numbering ' +
                  'from %d to %d' % (start_num, end_num))
-        enum[enum == -1] = np.arange(start_num, end_num)
+        enum[enum == -1] = np.arange(start_num, end_num, dtype=np.int32)
 
     # material type
     if 'ansys_material_type' in grid.cell_arrays:
         mtype = grid.cell_arrays['ansys_material_type']
     else:
         log.info('No ANSYS element numbers set in input.  ' +
-                 'Adding default range starting from %d' % mtype_start)
-        mtype = np.arange(1, ncells + 1)
+                 'Adding default range starting from %d', mtype_start)
+        mtype = np.arange(1, ncells + 1, dtype=np.int32)
 
     if np.any(mtype == -1):
         log.info('FEM missing some material type numbers.  Adding...')
@@ -402,8 +402,8 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
         rcon = grid.cell_arrays['ansys_real_constant']
     else:
         log.info('No ANSYS element numbers set in input.  ' +
-                 'Adding default range starting from %d' % real_constant_start)
-        rcon = np.arange(1, ncells + 1)
+                 'Adding default range starting from %d', real_constant_start)
+        rcon = np.arange(1, ncells + 1, dtype=np.int32)
 
     if np.any(rcon == -1):
         log.info('FEM missing some material type numbers.  Adding...')
@@ -479,187 +479,30 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
     elem_nnodes[typenum == 186] = 20
     elem_nnodes[typenum == 187] = 10
 
+    # write the EBLOCK
     with open(str(filename), mode) as f:
         f.write(header)
 
-        # write node block
-        if write_nblock:
-            write_nblock(f, nodenum, grid.points)
+    write_nblock(filename, nodenum, grid.points, mode='a')
 
-        # eblock header
-        h = ''
-        h += 'EBLOCK,19,SOLID,{:10d},{:10d}\n'.format(enum[-1], ncells)
-        h += '(19i8)\n'
-        f.write(h)
-
-        celltypes = grid.celltypes
-        cells, offset = vtk_cell_info(grid)
-        if VTK9:
-            offset += 1
-
-        for i in range(ncells):
-            if VTK9:
-                nodes = nodenum[cells[offset[i]:offset[i + 1]]]
-            else:
-                c = offset[i]
-                nnode = cells[c]
-                c += 1
-                nodes = nodenum[cells[c:c + nnode]]
-
-            cellinfo = (mtype[i],          # Field 1: material reference number
-                        etype[i],          # Field 2: element type number
-                        rcon[i],           # Field 3: real constant reference number
-                        1,                 # Field 4: section number
-                        0,                 # Field 5: element coordinate system
-                        0,                 # Field 6: Birth/death flag
-                        0,                 # Field 7:
-                        0,                 # Field 8:
-                        elem_nnodes[i],    # Field 9: Number of nodes
-                        0,                 # Field 10: Not Used
-                        enum[i])           # Field 11: Element number
-            line = '%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d' % cellinfo
-
-            if celltypes[i] == VTK_QUADRATIC_TETRA:
-                if typenum[i] == 187:
-                    line += '%8d%8d%8d%8d%8d%8d%8d%8d\n%8d%8d\n' % tuple(nodes)
-                else:  # must be 186
-                    writenodes = (nodes[0],  # 0,  I
-                                  nodes[1],  # 1,  J
-                                  nodes[2],  # 2,  K
-                                  nodes[2],  # 3,  L (duplicate of K)
-                                  nodes[3],  # 4,  M
-                                  nodes[3],  # 5,  N (duplicate of M)
-                                  nodes[3],  # 6,  O (duplicate of M)
-                                  nodes[3],  # 7,  P (duplicate of M)
-                                  nodes[4],  # 8,  Q
-                                  nodes[5],  # 9,  R
-                                  nodes[3],  # 10, S (duplicate of K)
-                                  nodes[6],  # 11, T
-                                  nodes[3],  # 12, U (duplicate of M)
-                                  nodes[3],  # 13, V (duplicate of M)
-                                  nodes[3],  # 14, W (duplicate of M)
-                                  nodes[3],  # 15, X (duplicate of M)
-                                  nodes[7],  # 16, Y
-                                  nodes[8],  # 17, Z
-                                  nodes[9],  # 18, A
-                                  nodes[9])  # 19, B (duplicate of A)
-
-                    line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes[:8]
-                    line += '%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes[8:]
+    # write remainder of eblock
+    cells, offset = vtk_cell_info(grid, shift_offset=False)
+    _archive.py_write_eblock(filename,
+                             enum,
+                             etype,
+                             mtype,
+                             rcon,
+                             elem_nnodes,
+                             cells,
+                             offset,
+                             grid.celltypes,
+                             typenum,
+                             nodenum,
+                             VTK9,
+                             mode='a')
 
 
-            elif celltypes[i] == VTK_TETRA:
-                writenodes = (nodes[0],  # 0,  I
-                              nodes[1],  # 1,  J
-                              nodes[2],  # 2,  K
-                              nodes[2],  # 3,  L (duplicate of K)
-                              nodes[3],  # 4,  M
-                              nodes[3],  # 5,  N (duplicate of M)
-                              nodes[3],  # 6,  O (duplicate of M)
-                              nodes[3])  # 7,  P (duplicate of M)
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes
-
-            elif celltypes[i] == VTK_WEDGE:
-                writenodes = (nodes[2],  # 0,  I
-                              nodes[1],  # 1,  J
-                              nodes[0],  # 2,  K
-                              nodes[0],  # 3,  L (duplicate of K)
-                              nodes[5],  # 4,  M
-                              nodes[4],  # 5,  N
-                              nodes[3],  # 6,  O
-                              nodes[3])  # 7,  P (duplicate of O)
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes
-
-            elif celltypes[i] == VTK_QUADRATIC_WEDGE:
-                writenodes = (nodes[2],  # 0,  I
-                              nodes[1],  # 1,  J
-                              nodes[0],  # 2,  K
-                              nodes[0],  # 3,  L (duplicate of K)
-                              nodes[5],  # 4,  M
-                              nodes[4],  # 5,  N
-                              nodes[3],  # 6,  O
-                              nodes[3],  # 7,  P (duplicate of O)
-                              nodes[7],  # 8,  Q
-                              nodes[6],  # 9,  R
-                              nodes[0],  # 10, S   (duplicate of K)
-                              nodes[8],  # 11, T
-                              nodes[10], # 12, U
-                              nodes[9],  # 13, V
-                              nodes[3],  # 14, W (duplicate of O)
-                              nodes[11], # 15, X
-                              nodes[14], # 16, Y
-                              nodes[13], # 17, Z
-                              nodes[12], # 18, A
-                              nodes[12]) # 19, B (duplicate of A)
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes[:8]
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes[8:]
-
-            elif celltypes[i] == VTK_QUADRATIC_PYRAMID:
-                writenodes = (nodes[0],  # 0,  I
-                              nodes[1],  # 1,  J
-                              nodes[2],  # 2,  K
-                              nodes[3],  # 3,  L
-                              nodes[4],  # 4,  M
-                              nodes[4],  # 5,  N (duplicate of M)
-                              nodes[4],  # 6,  O (duplicate of M)
-                              nodes[4],  # 7,  P (duplicate of M)
-                              nodes[5],  # 8,  Q
-                              nodes[6],  # 9,  R
-                              nodes[7],  # 10, S
-                              nodes[8],  # 11, T
-                              nodes[4],  # 12, U (duplicate of M)
-                              nodes[4],  # 13, V (duplicate of M)
-                              nodes[4],  # 14, W (duplicate of M)
-                              nodes[4],  # 15, X (duplicate of M)
-                              nodes[9],  # 16, Y
-                              nodes[10], # 17, Z
-                              nodes[11], # 18, A
-                              nodes[12]) # 19, B (duplicate of A)
-
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes[:8]
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes[8:]
-
-            elif celltypes[i] == VTK_PYRAMID:
-                writenodes = (nodes[0],  # 0,  I
-                              nodes[1],  # 1,  J
-                              nodes[2],  # 2,  K
-                              nodes[3],  # 3,  L
-                              nodes[4],  # 4,  M
-                              nodes[4],  # 5,  N (duplicate of M)
-                              nodes[4],  # 6,  O (duplicate of M)
-                              nodes[4])  # 7,  P (duplicate of M)
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % writenodes[:8]
-
-            elif celltypes[i] == VTK_HEXAHEDRON:
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % tuple(nodes[:8])
-
-            elif celltypes[i] == VTK_QUADRATIC_HEXAHEDRON:
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d\n' % tuple(nodes[:8])
-                line += '%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n' % tuple(nodes[8:])
-
-            elif celltypes[i] == VTK_TRIANGLE:
-                writenodes = (nodes[0],  # 0,  I
-                              nodes[1],  # 1,  J
-                              nodes[2],  # 2,  K
-                              nodes[2])  # 3,  L (duplicate of K)
-                line += '%8d%8d%8d%8d\n' % writenodes
-
-            elif celltypes[i] == VTK_QUAD:
-                writenodes = (nodes[0],  # 0,  I
-                              nodes[1],  # 1,  J
-                              nodes[2],  # 2,  K
-                              nodes[3])  # 3,  L
-                line += '%8d%8d%8d%8d\n' % writenodes
-
-            # else:
-            #     raise RuntimeError('Invalid write cell type %d' % celltypes[i])
-
-            f.write(line)
-
-        f.write('      -1\n')
-
-
-def write_nblock(filename, node_id, pos, angles=None):
+def write_nblock(filename, node_id, pos, angles=None, mode='w'):
     """Writes nodes and node angles to file.
 
     Parameters
@@ -675,55 +518,39 @@ def write_nblock(filename, node_id, pos, angles=None):
 
     angles : np.ndarray, optional
         Writes the node angles for each node when included.
+
+    mode : str, optional
+        Write mode.  Default ``'w'``.
     """
     assert pos.ndim == 2 and pos.shape[1] == 3, 'Invalid position array'
     if angles is not None:
         assert angles.ndim == 2 and angles.shape[1] == 3, 'Invalid angle array'
 
-    # Header Tell ANSYS to start reading the node block with 6 fields,
-    # associated with a solid, the maximum node number and the number
-    # of lines in the node block
-    h = '/PREP7 \n'
-    h += 'NBLOCK,6,SOLID,%10d,%10d\n' % (np.max(node_id), pos.shape[0])
-    h += '(3i8,6e20.13)'
+    if node_id.dtype != np.int32:
+        node_id = node_id.astype(np.int32)
 
-    # NBLOCK footer
-    f = 'N,R5.3,LOC,       -1, \n'
+    # node array must be sorted
+    # note, this is sort check is most suited for pre-sorted arrays
+    # see https://stackoverflow.com/questions/3755136/
+    if not np.all(node_id[:-1] <= node_id[1:]):
+        sidx = np.argsort(node_id)
+        node_id = node_id[sidx]
+        pos = pos[sidx]
 
-    # Sort input data
-    ind = np.argsort(node_id)
-    node_id = node_id[ind]
-    pos = pos[ind]
-
-    if angles is None:
-        np.savetxt(
-            filename,
-            np.hstack((node_id.reshape(-1, 1), pos)),
-            '%8d       0       0' +
-            '%20.12E' *
-            3,
-            header=h,
-            footer=f,
-            comments='',
-            newline='\n')
+    if angles is not None:
+        _archive.py_write_nblock(filename,
+                                 node_id,
+                                 node_id[-1],
+                                 pos,
+                                 angles,
+                                 mode)
     else:
-        # Array of node positions and angles
-        arr = np.empty((node_id.size, 7))
-        arr[:, 0] = node_id
-        arr[:, 1:4] = pos
-        arr[:, 4:] = angles
-
-        # stack node IDs and positions
-        np.savetxt(
-            filename,
-            arr,
-            '%8d       0       0' +
-            '%20.12E' *
-            6,
-            header=h,
-            footer=f,
-            comments='',
-            newline='\n')
+        _archive.py_write_nblock(filename,
+                                 node_id,
+                                 node_id[-1],
+                                 pos,
+                                 np.empty((0, 0)),
+                                 mode)
 
 
 def write_cmblock(filename, items, comp_name, comp_type, digit_width=10):

--- a/ansys/mapdl/reader/cython/_archive.pyx
+++ b/ansys/mapdl/reader/cython/_archive.pyx
@@ -1,0 +1,84 @@
+# cython: language_level=3
+# cython: infer_types=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
+# cython: nonecheck=False
+# cython: embedsignature=True
+
+from libc.stdio cimport fopen, fclose, FILE
+
+ctypedef unsigned char uint8_t
+from libc.stdint cimport int64_t
+
+
+cdef extern from 'archive.h' nogil:
+    int write_nblock(FILE*, const int, const int, const int*, const double*,
+                     const double*, int)
+    int write_eblock(FILE*, const int, const int*, const int*, const int*,
+                     const int*, const int*, const uint8_t*, const int64_t*,
+                     const int64_t*, const int*, const int*, const int);
+
+
+def py_write_nblock(filename, const int [::1] node_id, int max_node_id,
+                    const double [:, ::1] pos, const double [:, ::1] angles,
+                    mode='w'):
+    """Write a node block to a file.
+
+    Parameters
+    ----------
+    fid : _io.TextIOWrapper
+        Opened Python file object.
+
+    node_id : np.ndarray
+        Array of node ids.
+
+    pos : np.ndarray
+        Double array of node coordinates
+
+    angles : np.ndarray, optional
+        
+
+    """
+    # attach the stream to the python file
+    cdef FILE* cfile = fopen(filename.encode(), mode.encode())
+
+    cdef int n_nodes = pos.shape[0]
+    cdef double [::1] dummy_arr
+
+    cdef int has_angles = 0
+    if angles.size == pos.size:
+        has_angles = 1
+    write_nblock(cfile, n_nodes, max_node_id, &node_id[0], &pos[0, 0],
+                 &angles[0, 0], has_angles);
+    fclose(cfile)
+
+
+def py_write_eblock(filename,
+                    int [::1] elem_id,
+                    int [::1] etype,
+                    int [::1] mtype,
+                    int [::1] rcon,
+                    int [::1] elem_nnodes,
+                    int64_t [::1] cells,
+                    int64_t [::1] offset,
+                    uint8_t [::1] celltypes,
+                    int [::1] typenum,
+                    int [::1] nodenum,
+                    vtk9,
+                    mode='w'):
+    cdef FILE* cfile = fopen(filename.encode(), mode.encode())
+    write_eblock(cfile,
+                 celltypes.size,
+                 &elem_id[0],
+                 &etype[0],
+                 &mtype[0],
+                 &rcon[0],
+                 &elem_nnodes[0],
+                 &celltypes[0],
+                 &offset[0],
+                 &cells[0],
+                 &typenum[0],
+                 &nodenum[0],
+                 int(vtk9))
+    fclose(cfile)

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -57,8 +57,6 @@ cdef extern from 'binary_reader.h' nogil:
     void read_nodes(const char*, int64_t, int, int*, double*)
     void* read_record(const char*, int64_t, int*, int*, int*, int*)
     void read_record_stream(ifstream*, int64_t, void*, int*, int*, int*)
-    int write_nblock(FILE*, const int, const int, const int*, const double*,
-                     const double*, int)
 
 
 # VTK numbering for vtk cells
@@ -1742,38 +1740,3 @@ def break_apart_surface(double [:, ::1] points, int64_t [::1] faces, int n_faces
         i += c_add  # extra increment because we're not recording all faces
 
     return np.array(new_points[:c]), np.array(new_faces[:cj]), np.array(orig_idx[:c])
-
-
-def py_write_nblock(filename, const int [::1] node_id, int max_node_id,
-                    const double [:, ::1] pos, const double [:, ::1] angles,
-                    mode='w'):
-    """Write a node block to a file.
-
-    Parameters
-    ----------
-    fid : _io.TextIOWrapper
-        Opened Python file object.
-
-    node_id : np.ndarray
-        Array of node ids.
-
-    pos : np.ndarray
-        Double array of node coordinates
-
-    angles : np.ndarray, optional
-        
-
-    """
-
-    # attach the stream to the python file
-    # encode is used here because I'm too lazy to change language_level --> 3
-    cdef FILE* cfile = fopen(filename.encode(), mode.encode())
-
-    cdef int n_nodes = pos.shape[0]
-    cdef double [::1] dummy_arr
-
-    cdef int has_angles = 0
-    if angles.size == pos.size:
-        has_angles = 1
-    write_nblock(cfile, n_nodes, max_node_id, &node_id[0], &pos[0, 0],
-                 &angles[0, 0], has_angles);

--- a/ansys/mapdl/reader/cython/_reader.pyx
+++ b/ansys/mapdl/reader/cython/_reader.pyx
@@ -571,3 +571,7 @@ def read_from_nwrite(filename, int nnodes):
 def write_array(filename, const double [::1] arr):
     cdef int nvalues = arr.size
     write_array_ascii(filename, &arr[0], nvalues)
+
+
+def write_nblock(filename, const int node_id, const double pos, angles):
+    pass

--- a/ansys/mapdl/reader/cython/_reader.pyx
+++ b/ansys/mapdl/reader/cython/_reader.pyx
@@ -4,10 +4,11 @@
 # cython: wraparound=False
 # cython: cdivision=True
 # cython: nonecheck=False
+# cython: embedsignature=True
 
 """ Cython implementation of a CDB reader """
-from libc.stdio cimport fopen, FILE, fclose, sscanf, fscanf, fread, fseek
-from libc.stdio cimport fgets, printf, SEEK_CUR, SEEK_END, ftell, SEEK_SET
+from libc.stdio cimport (fopen, FILE, fclose, sscanf, fscanf, fread, fseek,
+                         fgets, printf, SEEK_CUR, SEEK_END, ftell, SEEK_SET)
 from libc.stdlib cimport atoi, atof
 from libc.stdlib cimport malloc, free
 from libc.string cimport strncpy, strcmp
@@ -24,7 +25,8 @@ cdef extern from "reader.h":
     int read_nblock_from_nwrite(char*, int*, double*, int)
     int read_nblock(char*, int*, double*, int, int*, int, int*)
     int read_eblock(char*, int*, int*, int, int, int*)
-    int write_array_ascii(const char*, const double*, int nvalues);
+    int write_array_ascii(const char*, const double*, int);
+
 
 cdef extern from 'vtk_support.h':
     int ans_to_vtk(const int, const int*, const int*, const int*, const int,
@@ -571,7 +573,3 @@ def read_from_nwrite(filename, int nnodes):
 def write_array(filename, const double [::1] arr):
     cdef int nvalues = arr.size
     write_array_ascii(filename, &arr[0], nvalues)
-
-
-def write_nblock(filename, const int node_id, const double pos, angles):
-    pass

--- a/ansys/mapdl/reader/cython/_reader.pyx
+++ b/ansys/mapdl/reader/cython/_reader.pyx
@@ -208,12 +208,14 @@ def read(filename, read_parameters=False, debug=False):
                         print('EBLOCK already read, skipping...')
                     continue
                 if debug:
-                    print('reading EBLOCK')
+                    print('reading EBLOCK...')
 
                 # only read entries with SOLID
                 if b'SOLID' in line or b'solid' in line:
                     elem_sz, elem, elem_off = py_read_eblock(raw, n, line, fsize)
                     eblock_read = True
+                    if debug:
+                        print('finished')
 
         elif b'K' == line[0] or b'k' == line[0]:
             if b'KEYOP' in line or b'keyop' in line:

--- a/ansys/mapdl/reader/cython/archive.c
+++ b/ansys/mapdl/reader/cython/archive.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-
+#include <inttypes.h>
 
 // necessary for ubuntu build on azure
 #ifdef __linux__

--- a/ansys/mapdl/reader/cython/archive.c
+++ b/ansys/mapdl/reader/cython/archive.c
@@ -1,0 +1,268 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+
+// necessary for ubuntu build on azure
+#ifdef __linux__
+  #include <stdint.h>
+#endif
+
+// VTK cell types
+#define VTK_TRIANGLE 5
+#define VTK_QUAD 9
+#define VTK_TETRA 10
+#define VTK_HEXAHEDRON 12
+#define VTK_WEDGE 13
+#define VTK_PYRAMID 14
+#define VTK_QUADRATIC_TETRA 24
+#define VTK_QUADRATIC_HEXAHEDRON 25
+#define VTK_QUADRATIC_WEDGE 26
+#define VTK_QUADRATIC_PYRAMID 27
+
+// Write node IDs, node coordinates, and angles to file as a NBLOCK
+int write_nblock(FILE *file, const int n_nodes, const int max_node_id,
+                 const int *node_id, const double *nodes, const double *angles,
+                 int has_angles){
+  // Header
+  // Tell ANSYS to start reading the node block with 6 fields,
+  // associated with a solid, the maximum node number and the number
+  // of lines in the node block
+  fprintf(file, "/PREP7\n");
+  fprintf(file, "NBLOCK,6,SOLID,%10d,%10d\n", max_node_id, n_nodes);
+  fprintf(file, "(3i8,6e20.13)\n");
+
+  int i;
+  if (has_angles) {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(file,
+              "%8d       0       0%20.12E%20.12E%20.12E%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2],
+              angles[i*3 + 0], angles[i*3 + 1], angles[i*3 + 2]);
+    }
+  }
+  else {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(file,
+              "%8d       0       0%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2]);
+    }
+  }
+
+  fprintf(file, "N,R5.3,LOC,       -1,\n");
+  return 0;
+}
+
+
+// Write an ANSYS EBLOCK to file
+int write_eblock(FILE *file,
+                 const int n_elem,         // number of elements
+                 const int *elem_id,       // element ID array
+                 const int *etype,         // element type ID array
+                 const int *mtype,         // material ID array
+                 const int *rcon,          // real constant ID array
+                 const int *elem_nnodes,   // number of nodes per element
+                 const uint8_t *celltypes, // VTK celltypes array
+                 const int64_t *offset,    // VTK offset array
+                 const int64_t *cells,     // VTK cells array
+                 const int *typenum,       // ANSYS type number (e.g. 187 for SOLID187)
+                 const int *nodenum,       // ANSYS node numbering
+                 const int vtk9){          // connectivity array is VTK9 format
+
+  // Write header
+  fprintf(file, "EBLOCK,19,SOLID,%10d,%10d\n", elem_id[n_elem - 1], n_elem);
+  fprintf(file, "(19i8)\n");
+
+  int c;  // position within offset array
+  for (int i=0; i<n_elem; i++){
+    // Position within offset array
+    if (vtk9){
+      c = offset[i];
+    } else {
+      c = offset[i + 1];
+    }
+
+    // Write cell info
+    fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d",
+            mtype[i],          // Field 1: material reference number
+            etype[i],          // Field 2: element type number
+            rcon[i],           // Field 3: real constant reference number
+            1,                 // Field 4: section number
+            0,                 // Field 5: element coordinate system
+            0,                 // Field 6: Birth/death flag
+            0,                 // Field 7:
+            0,                 // Field 8:
+            elem_nnodes[i],    // Field 9: Number of nodes
+            0,                 // Field 10: Not Used
+            elem_id[i]);       // Field 11: Element number
+
+    // Write element nodes
+    switch (celltypes[i]){
+    case VTK_QUADRATIC_TETRA:
+      if (typenum[i] == 187){
+        fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n%8d%8d\n",
+                nodenum[cells[c + 0]],
+                nodenum[cells[c + 1]],
+                nodenum[cells[c + 2]],
+                nodenum[cells[c + 3]],
+                nodenum[cells[c + 4]],
+                nodenum[cells[c + 5]],
+                nodenum[cells[c + 6]],
+                nodenum[cells[c + 7]],
+                nodenum[cells[c + 8]],
+                nodenum[cells[c + 9]]);
+      } else {
+        fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n",
+                nodenum[cells[c + 0]],  // 0,  I
+                nodenum[cells[c + 1]],  // 1,  J
+                nodenum[cells[c + 2]],  // 2,  K
+                nodenum[cells[c + 2]],  // 3,  L (duplicate of K)
+                nodenum[cells[c + 3]],  // 4,  M
+                nodenum[cells[c + 3]],  // 5,  N (duplicate of M)
+                nodenum[cells[c + 3]],  // 6,  O (duplicate of M)
+                nodenum[cells[c + 3]],  // 7,  P (duplicate of M)
+                nodenum[cells[c + 4]],  // 8,  Q
+                nodenum[cells[c + 5]],  // 9,  R
+                nodenum[cells[c + 3]],  // 10, S (duplicate of K)
+                nodenum[cells[c + 6]],  // 11, T
+                nodenum[cells[c + 3]],  // 12, U (duplicate of M)
+                nodenum[cells[c + 3]],  // 13, V (duplicate of M)
+                nodenum[cells[c + 3]],  // 14, W (duplicate of M)
+                nodenum[cells[c + 3]],  // 15, X (duplicate of M)
+                nodenum[cells[c + 7]],  // 16, Y
+                nodenum[cells[c + 8]],  // 17, Z
+                nodenum[cells[c + 9]],  // 18, A
+                nodenum[cells[c + 9]]); // 19, B (duplicate of A)
+      }
+      break;
+      case VTK_TETRA: // point
+        fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n",
+                nodenum[cells[c + 0]],  // 0,  I
+                nodenum[cells[c + 1]],  // 1,  J
+                nodenum[cells[c + 2]],  // 2,  K
+                nodenum[cells[c + 2]],  // 3,  L (duplicate of K)
+                nodenum[cells[c + 3]],  // 4,  M
+                nodenum[cells[c + 3]],  // 5,  N (duplicate of M)
+                nodenum[cells[c + 3]],  // 6,  O (duplicate of M)
+                nodenum[cells[c + 3]]); // 7,  P (duplicate of M)
+        break;
+      case VTK_WEDGE:
+        fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n",
+                nodenum[cells[c + 2]],  // 0,  I
+                nodenum[cells[c + 1]],  // 1,  J
+                nodenum[cells[c + 0]],  // 2,  K
+                nodenum[cells[c + 0]],  // 3,  L (duplicate of K)
+                nodenum[cells[c + 5]],  // 4,  M
+                nodenum[cells[c + 4]],  // 5,  N
+                nodenum[cells[c + 3]],  // 6,  O
+                nodenum[cells[c + 3]]); // 7,  P (duplicate of O)
+        break;
+    case VTK_QUADRATIC_WEDGE:
+      fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n",
+              nodenum[cells[c + 2]],  // 0,  I
+              nodenum[cells[c + 1]],  // 1,  J
+              nodenum[cells[c + 0]],  // 2,  K
+              nodenum[cells[c + 0]],  // 3,  L (duplicate of K)
+              nodenum[cells[c + 5]],  // 4,  M
+              nodenum[cells[c + 4]],  // 5,  N
+              nodenum[cells[c + 3]],  // 6,  O
+              nodenum[cells[c + 3]],  // 7,  P (duplicate of O)
+              nodenum[cells[c + 7]],  // 8,  Q
+              nodenum[cells[c + 6]],  // 9,  R
+              nodenum[cells[c + 0]],  // 10, S   (duplicate of K)
+              nodenum[cells[c + 8]],  // 11, T
+              nodenum[cells[c + 10]], // 12, U
+              nodenum[cells[c + 9]],  // 13, V
+              nodenum[cells[c + 3]],  // 14, W (duplicate of O)
+              nodenum[cells[c + 11]], // 15, X
+              nodenum[cells[c + 14]], // 16, Y
+              nodenum[cells[c + 13]], // 17, Z
+              nodenum[cells[c + 12]], // 18, A
+              nodenum[cells[c + 12]]);// 19, B (duplicate of A)
+      break;
+    case VTK_QUADRATIC_PYRAMID:
+      fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n",
+              nodenum[cells[c + 0]],  // 0,  I
+              nodenum[cells[c + 1]],  // 1,  J
+              nodenum[cells[c + 2]],  // 2,  K
+              nodenum[cells[c + 3]],  // 3,  L
+              nodenum[cells[c + 4]],  // 4,  M
+              nodenum[cells[c + 4]],  // 5,  N (duplicate of M)
+              nodenum[cells[c + 4]],  // 6,  O (duplicate of M)
+              nodenum[cells[c + 4]],  // 7,  P (duplicate of M)
+              nodenum[cells[c + 5]],  // 8,  Q
+              nodenum[cells[c + 6]],  // 9,  R
+              nodenum[cells[c + 7]],  // 10, S
+              nodenum[cells[c + 8]],  // 11, T
+              nodenum[cells[c + 4]],  // 12, U (duplicate of M)
+              nodenum[cells[c + 4]],  // 13, V (duplicate of M)
+              nodenum[cells[c + 4]],  // 14, W (duplicate of M)
+              nodenum[cells[c + 4]],  // 15, X (duplicate of M)
+              nodenum[cells[c + 9]],  // 16, Y
+              nodenum[cells[c + 10]], // 17, Z
+              nodenum[cells[c + 11]], // 18, A
+              nodenum[cells[c + 12]]);// 19, B (duplicate of A)
+      break;
+    case VTK_PYRAMID:
+      fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n",
+              nodenum[cells[c + 0]],  // 0,  I
+              nodenum[cells[c + 1]],  // 1,  J
+              nodenum[cells[c + 2]],  // 2,  K
+              nodenum[cells[c + 3]],  // 3,  L
+              nodenum[cells[c + 4]],  // 4,  M
+              nodenum[cells[c + 4]],  // 5,  N (duplicate of M)
+              nodenum[cells[c + 4]],  // 6,  O (duplicate of M)
+              nodenum[cells[c + 4]]); // 7,  P (duplicate of M)
+      break;
+    case VTK_HEXAHEDRON:
+      fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n",
+              nodenum[cells[c + 0]],
+              nodenum[cells[c + 1]],
+              nodenum[cells[c + 2]],
+              nodenum[cells[c + 3]],
+              nodenum[cells[c + 4]],
+              nodenum[cells[c + 5]],
+              nodenum[cells[c + 6]],
+              nodenum[cells[c + 7]]);
+      break;
+    case VTK_QUADRATIC_HEXAHEDRON:
+      fprintf(file, "%8d%8d%8d%8d%8d%8d%8d%8d\n%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d\n",
+              nodenum[cells[c + 0]],
+              nodenum[cells[c + 1]],
+              nodenum[cells[c + 2]],
+              nodenum[cells[c + 3]],
+              nodenum[cells[c + 4]],
+              nodenum[cells[c + 5]],
+              nodenum[cells[c + 6]],
+              nodenum[cells[c + 7]],
+              nodenum[cells[c + 8]],
+              nodenum[cells[c + 9]],
+              nodenum[cells[c + 10]],
+              nodenum[cells[c + 11]],
+              nodenum[cells[c + 12]],
+              nodenum[cells[c + 13]],
+              nodenum[cells[c + 14]],
+              nodenum[cells[c + 15]],
+              nodenum[cells[c + 16]],
+              nodenum[cells[c + 17]],
+              nodenum[cells[c + 18]],
+              nodenum[cells[c + 19]]);
+      break;
+    case VTK_TRIANGLE:
+      fprintf(file, "%8d%8d%8d%8d\n",
+              nodenum[cells[c + 0]],  // 0,  I
+              nodenum[cells[c + 1]],  // 1,  J
+              nodenum[cells[c + 2]],  // 2,  K
+              nodenum[cells[c + 2]]); // 3,  L (duplicate of K)
+      break;
+    case VTK_QUAD:
+      fprintf(file, "%8d%8d%8d%8d\n",
+              nodenum[cells[c + 0]],  // 0,  I
+              nodenum[cells[c + 1]],  // 1,  J
+              nodenum[cells[c + 2]],  // 2,  K
+              nodenum[cells[c + 3]]); // 3,  L
+      break;
+    }
+  }
+  fprintf(file, "      -1\n");
+  return 0;
+}

--- a/ansys/mapdl/reader/cython/archive.h
+++ b/ansys/mapdl/reader/cython/archive.h
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __linux__
+  #include <stdint.h>
+#endif
+
+
+int write_nblock(FILE*, const int, const int, const int*, const double*,
+                 const double*, int);
+int write_eblock(FILE*, const int, const int*, const int*, const int*,
+                 const int*, const int*, const uint8_t*, const int64_t*,
+                 const int64_t*, const int*, const int*, const int);

--- a/ansys/mapdl/reader/cython/binary_reader.cpp
+++ b/ansys/mapdl/reader/cython/binary_reader.cpp
@@ -529,39 +529,3 @@ void read_nodes(const char* filename, int64_t ptrLOC, int nrec, int *nnum,
   delete[] raw;
 
 }
-
-
-// Simply write an array to disk as ASCII
-int write_nblock(FILE * file, const int n_nodes, const int max_node_id,
-                 const int *node_id, const double *nodes, const double *angles,
-                 int has_angles){
-  // Header
-  // Tell ANSYS to start reading the node block with 6 fields,
-  // associated with a solid, the maximum node number and the number
-  // of lines in the node block
-  fprintf(file, "/PREP7\n");
-  fprintf(file, "NBLOCK,6,SOLID,%10d,%10d\n", max_node_id, n_nodes);
-  fprintf(file, "(3i8,6e20.13)\n");
-
-  int i;
-  if (has_angles) {
-    for (i=0; i<n_nodes; i++) {
-      fprintf(file,
-              "%8d       0       0%20.12E%20.12E%20.12E%20.12E%20.12E%20.12E\n",
-              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2],
-              angles[i*3 + 0], angles[i*3 + 1], angles[i*3 + 2]);
-    }
-  }
-  else {
-    for (i=0; i<n_nodes; i++) {
-      fprintf(file,
-              "%8d       0       0%20.12E%20.12E%20.12E\n",
-              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2]);
-    }
-  }
-
-  fclose(file);
-
-  return 0;
-}
-

--- a/ansys/mapdl/reader/cython/binary_reader.cpp
+++ b/ansys/mapdl/reader/cython/binary_reader.cpp
@@ -529,3 +529,39 @@ void read_nodes(const char* filename, int64_t ptrLOC, int nrec, int *nnum,
   delete[] raw;
 
 }
+
+
+// Simply write an array to disk as ASCII
+int write_nblock(FILE * file, const int n_nodes, const int max_node_id,
+                 const int *node_id, const double *nodes, const double *angles,
+                 int has_angles){
+  // Header
+  // Tell ANSYS to start reading the node block with 6 fields,
+  // associated with a solid, the maximum node number and the number
+  // of lines in the node block
+  fprintf(file, "/PREP7\n");
+  fprintf(file, "NBLOCK,6,SOLID,%10d,%10d\n", max_node_id, n_nodes);
+  fprintf(file, "(3i8,6e20.13)\n");
+
+  int i;
+  if (has_angles) {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(file,
+              "%8d       0       0%20.12E%20.12E%20.12E%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2],
+              angles[i*3 + 0], angles[i*3 + 1], angles[i*3 + 2]);
+    }
+  }
+  else {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(file,
+              "%8d       0       0%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2]);
+    }
+  }
+
+  fclose(file);
+
+  return 0;
+}
+

--- a/ansys/mapdl/reader/cython/binary_reader.h
+++ b/ansys/mapdl/reader/cython/binary_reader.h
@@ -4,5 +4,3 @@
 void read_nodes(const char*, int64_t, int, int *, double *);
 void* read_record(const char*, int64_t, int*, int*, int*, int*);
 void read_record_stream(std::ifstream*, int64_t, void*, int*, int*, int*);
-int write_nblock(FILE*, const int, const int, const int*, const double*,
-                 const double*, int);

--- a/ansys/mapdl/reader/cython/binary_reader.h
+++ b/ansys/mapdl/reader/cython/binary_reader.h
@@ -1,5 +1,8 @@
+#include <stdio.h>
 /* #include <fstream> */
 
 void read_nodes(const char*, int64_t, int, int *, double *);
 void* read_record(const char*, int64_t, int*, int*, int*, int*);
 void read_record_stream(std::ifstream*, int64_t, void*, int*, int*, int*);
+int write_nblock(FILE*, const int, const int, const int*, const double*,
+                 const double*, int);

--- a/ansys/mapdl/reader/cython/reader.c
+++ b/ansys/mapdl/reader/cython/reader.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <math.h>
 
+
 //=============================================================================
 // Fast string to integer convert to ANSYS formatted integers 
 //=============================================================================
@@ -470,39 +471,3 @@ int write_array_ascii(const char* filename, const double *arr,
 
   return 0;
 }
-
-// Simply write an array to disk as ASCII
-int write_nblock(const char* filename, const int n_nodes, const int max_node_id,
-                 const int *node_id, const double *nodes, const double *angles,
-                 int has_angles){
-  FILE * fstream = fopen(filename, "w");
-  int i;
-
-  // Header Tell ANSYS to start reading the node block with 6 fields,
-  // associated with a solid, the maximum node number and the number
-  // of lines in the node block
-  fprintf(fstream, "/PREP7\n");
-  fprintf(fstream, "NBLOCK,6,SOLID,%10d,%10d\n", max_node_id, n_nodes);
-  fprintf(fstream, "(3i8,6e20.13)\n");
-
-  if (has_angles) {
-    for (i=0; i<n_nodes; i++) {
-      fprintf(fstream,
-              "%8d       0       0%20.12E%20.12E%20.12E%20.12E%20.12E%20.12E\n",
-              node_id[i], nodes[i + 0], nodes[i + 1], nodes[i + 2],
-              angles[i + 0], angles[i + 1], angles[i + 2]);
-    }
-  }
-  else {
-    for (i=0; i<n_nodes; i++) {
-      fprintf(fstream,
-              "%8d       0       0%20.12E%20.12E%20.12E\n",
-              node_id[i], nodes[i + 0], nodes[i + 1], nodes[i + 2]);
-    }
-  }
-
-  fclose(fstream);
-
-  return 0;
-}
-

--- a/ansys/mapdl/reader/cython/reader.c
+++ b/ansys/mapdl/reader/cython/reader.c
@@ -471,8 +471,38 @@ int write_array_ascii(const char* filename, const double *arr,
   return 0;
 }
 
+// Simply write an array to disk as ASCII
+int write_nblock(const char* filename, const int n_nodes, const int max_node_id,
+                 const int *node_id, const double *nodes, const double *angles,
+                 int has_angles){
+  FILE * fstream = fopen(filename, "w");
+  int i;
 
-/* int main(){ */
-/*   const char* filename = "/tmp/ */
-/*   read_nblock_from_nwrite( filename, int *nnum, double *nodes, */
-/* 			  int nnodes){ */
+  // Header Tell ANSYS to start reading the node block with 6 fields,
+  // associated with a solid, the maximum node number and the number
+  // of lines in the node block
+  fprintf(fstream, "/PREP7\n");
+  fprintf(fstream, "NBLOCK,6,SOLID,%10d,%10d\n", max_node_id, n_nodes);
+  fprintf(fstream, "(3i8,6e20.13)\n");
+
+  if (has_angles) {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(fstream,
+              "%8d       0       0%20.12E%20.12E%20.12E%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i + 0], nodes[i + 1], nodes[i + 2],
+              angles[i + 0], angles[i + 1], angles[i + 2]);
+    }
+  }
+  else {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(fstream,
+              "%8d       0       0%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i + 0], nodes[i + 1], nodes[i + 2]);
+    }
+  }
+
+  fclose(fstream);
+
+  return 0;
+}
+

--- a/ansys/mapdl/reader/cython/reader.h
+++ b/ansys/mapdl/reader/cython/reader.h
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 int read_nblock(char*, int*, double*, int, int*, int, int*);
 int read_eblock(char*, int*, int*, int, int, int*);
 int read_nblock_from_nwrite(char*, int*, double*, int);

--- a/ansys/mapdl/reader/misc.py
+++ b/ansys/mapdl/reader/misc.py
@@ -13,8 +13,16 @@ import vtk
 VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
 
 
-def vtk_cell_info(grid):
+def vtk_cell_info(grid, force_int64=True, shift_offset=True):
     """Returns version consistent connectivity and cell offset arrays.
+
+    Parameters
+    ----------
+    force_int64 : bool, optional
+        Force output arrays to be uint64
+
+    shift_offset : bool, optional
+        Shift the offset by -1 when VTK9
 
     Notes
     -----
@@ -39,21 +47,19 @@ def vtk_cell_info(grid):
 
     """
     if VTK9:
-        # for pyvista < 0.25.0
-        if not hasattr(grid, 'cell_connectivity'):
-            carr = grid.GetCells()
-            cells = vtk.util.numpy_support.vtk_to_numpy(carr.GetConnectivityArray())
+        cells = grid.cell_connectivity
+        if shift_offset:
+            offset = grid.offset - 1
         else:
-            cells = grid.cell_connectivity
-        offset = grid.offset - 1
+            offset = grid.offset
     else:
         cells, offset = grid.cells, grid.offset
 
-    if cells.dtype != np.int64:
-        cells = cells.astype(np.int64)
-
-    if offset.dtype != np.int64:
-        offset = offset.astype(np.int64)
+    if force_int64:
+        if cells.dtype != np.int64:
+            cells = cells.astype(np.int64)
+        if offset.dtype != np.int64:
+            offset = offset.astype(np.int64)
 
     return cells, offset
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       displayName: Build wheels using manylinux2010
     - script: |
         .ci/setup_headless_display.sh
-    - template: .ci/install_pyansys.yml
+    - template: .ci/install_package.yml
     - template: .ci/unit_testing.yml
     - template: .ci/azure-publish-dist.yml
 
@@ -68,7 +68,7 @@ jobs:
         powershell .ci/install_opengl.ps1
       displayName: 'Install OpenGL'
     - template: .ci/build_wheel.yml
-    - template: .ci/install_pyansys.yml
+    - template: .ci/install_package.yml
     - template: .ci/unit_testing.yml
     - template: .ci/azure-publish-dist.yml
 
@@ -88,7 +88,7 @@ jobs:
     - script: .ci/macos-install-python.sh '$(python.version)'
       displayName: Install Python
     - template: .ci/build_wheel.yml
-    - template: .ci/install_pyansys.yml
+    - template: .ci/install_package.yml
     - template: .ci/unit_testing_allow_error.yml
     - template: .ci/azure-publish-dist.yml
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy>=1.14.0
+pyvista>=0.27.2
+appdirs>=1.4.0
+tqdm>=4.45.0

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,12 @@ setup(
     # Build cython modules
     cmdclass={'build_ext': build_ext},
     ext_modules=[
+                 Extension('ansys.mapdl.reader._archive',
+                           ['ansys/mapdl/reader/cython/_archive.pyx',
+                            'ansys/mapdl/reader/cython/archive.c'],
+                           extra_compile_args=cmp_arg,
+                           language='c',),
+
                  Extension('ansys.mapdl.reader._reader',
                            ['ansys/mapdl/reader/cython/_reader.pyx',
                             'ansys/mapdl/reader/cython/reader.c',

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -307,3 +307,28 @@ def test_read_hypermesh():
     filename = os.path.join(testfiles_path, 'hypermesh.cdb')
     archive = pymapdl_reader.Archive(filename, verbose=True)
     assert np.allclose(archive.nodes[:6], expected)
+
+
+@pytest.mark.parametrize('angles', [True, False])
+def test_cython_write_nblock(hex_archive, tmpdir, angles):
+    from ansys.mapdl.reader import _reader
+    nblock_filename = str(tmpdir.mkdir("tmpdir").join('nblock.inp'))
+
+    if angles:
+        _reader.py_write_nblock(nblock_filename,
+                                hex_archive.nnum,
+                                hex_archive.nnum[-1],
+                                hex_archive.nodes,
+                                hex_archive.node_angles)
+    else:
+        _reader.py_write_nblock(nblock_filename,
+                                hex_archive.nnum,
+                                hex_archive.nnum[-1],
+                                hex_archive.nodes,
+                                np.empty((0, 0)))
+
+    tmp_archive = pymapdl_reader.Archive(nblock_filename)
+    assert np.allclose(hex_archive.nnum, tmp_archive.nnum)
+    assert np.allclose(hex_archive.nodes, tmp_archive.nodes)
+    if angles:
+        assert np.allclose(hex_archive.node_angles, tmp_archive.node_angles)

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -11,7 +11,7 @@ import pyvista as pv
 import vtk
 
 from ansys.mapdl import reader as pymapdl_reader
-from ansys.mapdl.reader import examples, _archive
+from ansys.mapdl.reader import examples
 from ansys.mapdl.reader.misc import vtk_cell_info
 
 LINEAR_CELL_TYPES = [VTK_TETRA,
@@ -314,17 +314,17 @@ def test_cython_write_nblock(hex_archive, tmpdir, angles):
     nblock_filename = str(tmpdir.mkdir("tmpdir").join('nblock.inp'))
 
     if angles:
-        _archive.py_write_nblock(nblock_filename,
-                                 hex_archive.nnum,
-                                 hex_archive.nnum[-1],
-                                 hex_archive.nodes,
-                                 hex_archive.node_angles)
+        pymapdl_reader._archive.py_write_nblock(nblock_filename,
+                                                hex_archive.nnum,
+                                                hex_archive.nnum[-1],
+                                                hex_archive.nodes,
+                                                hex_archive.node_angles)
     else:
-        _archive.py_write_nblock(nblock_filename,
-                                 hex_archive.nnum,
-                                 hex_archive.nnum[-1],
-                                 hex_archive.nodes,
-                                 np.empty((0, 0)))
+        pymapdl_reader._archive.py_write_nblock(nblock_filename,
+                                                hex_archive.nnum,
+                                                hex_archive.nnum[-1],
+                                                hex_archive.nodes,
+                                                np.empty((0, 0)))
 
     tmp_archive = pymapdl_reader.Archive(nblock_filename)
     assert np.allclose(hex_archive.nnum, tmp_archive.nnum)
@@ -347,17 +347,15 @@ def test_cython_write_eblock(hex_archive):
     nodenum = hex_archive.nnum
 
     cells, offset = vtk_cell_info(hex_archive.grid, shift_offset=False)
-    _archive.py_write_eblock(filename,
-                             hex_archive.enum,
-                             etype,
-                             hex_archive.material_type,
-                             np.ones(hex_archive.n_elem, np.int32),
-                             elem_nnodes,
-                             cells,
-                             offset,
-                             hex_archive.grid.celltypes,
-                             typenum,
-                             nodenum,
-                             vtk9)
-
-    
+    pymapdl_reader._archive.py_write_eblock(filename,
+                                            hex_archive.enum,
+                                            etype,
+                                            hex_archive.material_type,
+                                            np.ones(hex_archive.n_elem, np.int32),
+                                            elem_nnodes,
+                                            cells,
+                                            offset,
+                                            hex_archive.grid.celltypes,
+                                            typenum,
+                                            nodenum,
+                                            vtk9)

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -8,10 +8,11 @@ from vtk import (VTK_TETRA, VTK_QUADRATIC_TETRA, VTK_PYRAMID,
                  VTK_QUADRATIC_HEXAHEDRON)
 from pyvista import examples as pyvista_examples
 import pyvista as pv
+import vtk
 
 from ansys.mapdl import reader as pymapdl_reader
-from ansys.mapdl.reader import examples
-
+from ansys.mapdl.reader import examples, _archive
+from ansys.mapdl.reader.misc import vtk_cell_info
 
 LINEAR_CELL_TYPES = [VTK_TETRA,
                      VTK_PYRAMID,
@@ -104,9 +105,9 @@ def test_missing_midside():
 
 
 def test_writehex(tmpdir, hex_archive):
-    temp_archive = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))
-    pymapdl_reader.save_as_archive(temp_archive, hex_archive.grid)
-    archive_new = pymapdl_reader.Archive(temp_archive)
+    filename = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))
+    pymapdl_reader.save_as_archive(filename, hex_archive.grid)
+    archive_new = pymapdl_reader.Archive(filename)
     assert np.allclose(hex_archive.grid.points, archive_new.grid.points)
     assert np.allclose(hex_archive.grid.cells, archive_new.grid.cells)
 
@@ -139,10 +140,9 @@ def test_writehex_missing_elem_num(tmpdir, hex_archive):
 def test_writehex_missing_node_num(tmpdir, hex_archive):
     hex_archive.grid.point_arrays['ansys_node_num'][:-1] = -1
 
-    temp_archive = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))
-    pymapdl_reader.save_as_archive(temp_archive, hex_archive.grid)
-    archive_new = pymapdl_reader.Archive(temp_archive)
-
+    filename = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))
+    pymapdl_reader.save_as_archive(filename, hex_archive.grid)
+    archive_new = pymapdl_reader.Archive(filename)
     assert np.allclose(hex_archive.grid.points.shape, archive_new.grid.points.shape)
     assert np.allclose(hex_archive.grid.cells.size, archive_new.grid.cells.size)
 
@@ -266,11 +266,11 @@ def test_write_lin_archive(tmpdir, celltype, all_solid_cells_archive_linear):
 
 def test_write_component(tmpdir):
     items = np.array([1, 20, 50, 51, 52, 53])
-    temp_archive = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))
+    filename = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))
 
     comp_name = 'TEST'
-    pymapdl_reader.write_cmblock(temp_archive, items, comp_name, 'node')
-    archive = pymapdl_reader.Archive(temp_archive)
+    pymapdl_reader.write_cmblock(filename, items, comp_name, 'node')
+    archive = pymapdl_reader.Archive(filename)
     assert np.allclose(archive.node_components[comp_name], items)
 
 
@@ -311,24 +311,53 @@ def test_read_hypermesh():
 
 @pytest.mark.parametrize('angles', [True, False])
 def test_cython_write_nblock(hex_archive, tmpdir, angles):
-    from ansys.mapdl.reader import _reader
     nblock_filename = str(tmpdir.mkdir("tmpdir").join('nblock.inp'))
 
     if angles:
-        _reader.py_write_nblock(nblock_filename,
-                                hex_archive.nnum,
-                                hex_archive.nnum[-1],
-                                hex_archive.nodes,
-                                hex_archive.node_angles)
+        _archive.py_write_nblock(nblock_filename,
+                                 hex_archive.nnum,
+                                 hex_archive.nnum[-1],
+                                 hex_archive.nodes,
+                                 hex_archive.node_angles)
     else:
-        _reader.py_write_nblock(nblock_filename,
-                                hex_archive.nnum,
-                                hex_archive.nnum[-1],
-                                hex_archive.nodes,
-                                np.empty((0, 0)))
+        _archive.py_write_nblock(nblock_filename,
+                                 hex_archive.nnum,
+                                 hex_archive.nnum[-1],
+                                 hex_archive.nodes,
+                                 np.empty((0, 0)))
 
     tmp_archive = pymapdl_reader.Archive(nblock_filename)
     assert np.allclose(hex_archive.nnum, tmp_archive.nnum)
     assert np.allclose(hex_archive.nodes, tmp_archive.nodes)
     if angles:
         assert np.allclose(hex_archive.node_angles, tmp_archive.node_angles)
+
+
+def test_cython_write_eblock(hex_archive):
+    vtk9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
+    filename = '/tmp/eblock.inp'
+
+    etype = np.ones(hex_archive.n_elem, np.int32)
+    typenum = hex_archive.etype
+    elem_nnodes = np.empty(etype.size, np.int32)
+    elem_nnodes[typenum == 181] = 4
+    elem_nnodes[typenum == 185] = 8
+    elem_nnodes[typenum == 186] = 20
+    elem_nnodes[typenum == 187] = 10
+    nodenum = hex_archive.nnum
+
+    cells, offset = vtk_cell_info(hex_archive.grid, shift_offset=False)
+    _archive.py_write_eblock(filename,
+                             hex_archive.enum,
+                             etype,
+                             hex_archive.material_type,
+                             np.ones(hex_archive.n_elem, np.int32),
+                             elem_nnodes,
+                             cells,
+                             offset,
+                             hex_archive.grid.celltypes,
+                             typenum,
+                             nodenum,
+                             vtk9)
+
+    


### PR DESCRIPTION
The existing vtk to ANSYS archive writer is quite slow as it's implemented almost entirely in pure python.  This PR proposes using a C enabled archive writer to vastly improve the performance of the nblock and eblock writer.
