### PR TITLE
fix/archive writer vtk8.1

### DIFF
--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-reader module."""
 
 # major, minor, patch
-version_info = 0, 50, 2
+version_info = 0, 50, 3
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/reader/cython/archive.c
+++ b/ansys/mapdl/reader/cython/archive.c
@@ -78,7 +78,7 @@ int write_eblock(FILE *file,
     if (vtk9){
       c = offset[i];
     } else {
-      c = offset[i + 1];
+      c = offset[i] + 1;
     }
 
     // Write cell info

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,4 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy>=1.16.0
-cython==0.29.20
+numpy==1.20.1
+cython==0.29.21

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,4 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy==1.20.1
+numpy>=1.19.0
 cython==0.29.21

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -133,7 +133,6 @@ def test_write_angle(tmpdir, hex_archive):
     assert np.allclose(archive.nodes, hex_archive.nodes)
 
 
-@pytest.mark.xfail(True, reason='TODO: unexplained behavior')
 def test_missing_midside():
     allowable_types = [45, 95, 185, 186, 92, 187]
     archive_file = os.path.join(testfiles_path, 'mixed_missing_midside.cdb')
@@ -159,7 +158,6 @@ def test_writehex(tmpdir, hex_archive):
                            archive_new.element_components[element_component])
 
 
-@pytest.mark.xfail(os.name == 'nt', reason='TODO: Fails to write nodes on CI')
 def test_writesector(tmpdir):
     archive = pymapdl_reader.Archive(examples.sector_archive_file)
     filename = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))


### PR DESCRIPTION
This PR patches the build for the archive writer by specifying the `numpy` and `cython` versions explicitly.  It also fixes a bug with the archive reader where the offset array with vtk 8.1.2 is mis-indexed, leading to a segfault on windows.

Commits:
- fix archive writer for vtk 8.1.2
- disable skip and xpass for nt
