### PR TITLE
allow float nblocks

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -4,7 +4,7 @@ name: Style Check
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  check_style:
     runs-on: ubuntu-20.04
 
     steps:

--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-reader module."""
 
 # major, minor, patch
-version_info = 0, 50, 3
+version_info = 0, 50, 4
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -575,19 +575,38 @@ def write_nblock(filename, node_id, pos, angles=None, mode='w'):
         pos = pos[sidx]
 
     if angles is not None:
-        _archive.py_write_nblock(filename,
-                                 node_id,
-                                 node_id[-1],
-                                 pos,
-                                 angles,
-                                 mode)
+        if pos.dtype == np.float32:
+            if angles.dtype != pos.dtype:
+                angles = angles.astype(pos.dtype)
+            _archive.py_write_nblock_float(filename,
+                                           node_id,
+                                           node_id[-1],
+                                           pos,
+                                           angles,
+                                           mode)
+        else:
+            _archive.py_write_nblock(filename,
+                                     node_id,
+                                     node_id[-1],
+                                     pos,
+                                     angles,
+                                     mode)
+
     else:
-        _archive.py_write_nblock(filename,
-                                 node_id,
-                                 node_id[-1],
-                                 pos,
-                                 np.empty((0, 0)),
-                                 mode)
+        if pos.dtype == np.float32:
+            _archive.py_write_nblock_float(filename,
+                                           node_id,
+                                           node_id[-1],
+                                           pos,
+                                           np.empty((0, 0), dtype=np.float32),
+                                           mode)
+        else:
+            _archive.py_write_nblock(filename,
+                                     node_id,
+                                     node_id[-1],
+                                     pos,
+                                     np.empty((0, 0), dtype=np.float64),
+                                     mode)
 
 
 def write_cmblock(filename, items, comp_name, comp_type,

--- a/ansys/mapdl/reader/cython/_archive.pyx
+++ b/ansys/mapdl/reader/cython/_archive.pyx
@@ -19,6 +19,8 @@ from libc.stdint cimport int64_t
 cdef extern from 'archive.h' nogil:
     int write_nblock(FILE*, const int, const int, const int*, const double*,
                      const double*, int)
+    int write_nblock_float(FILE*, const int, const int, const int*, const float*,
+                           const float*, int)
     int write_eblock(FILE*, const int, const int*, const int*, const int*,
                      const int*, const int*, const uint8_t*, const int64_t*,
                      const int64_t*, const int*, const int*, const int);
@@ -48,13 +50,43 @@ def py_write_nblock(filename, const int [::1] node_id, int max_node_id,
     cdef FILE* cfile = fopen(filename.encode(), mode.encode())
 
     cdef int n_nodes = pos.shape[0]
-    cdef double [::1] dummy_arr
 
     cdef int has_angles = 0
     if angles.size == pos.size:
         has_angles = 1
     write_nblock(cfile, n_nodes, max_node_id, &node_id[0], &pos[0, 0],
                  &angles[0, 0], has_angles);
+    fclose(cfile)
+
+
+def py_write_nblock_float(filename, const int [::1] node_id, int max_node_id,
+                          const float [:, ::1] pos, const float [:, ::1] angles,
+                          mode='w'):
+    """Write a float32 node block to a file.
+
+    Parameters
+    ----------
+    fid : _io.TextIOWrapper
+        Opened Python file object.
+
+    node_id : np.ndarray
+        Array of node ids.
+
+    pos : np.float32 np.ndarray
+        Double array of node coordinates
+
+    angles : np.ndarray, optional
+    
+    """
+    # attach the stream to the python file
+    cdef FILE* cfile = fopen(filename.encode(), mode.encode())
+
+    cdef int n_nodes = pos.shape[0]
+    cdef int has_angles = 0
+    if angles.size == pos.size:
+        has_angles = 1
+    write_nblock_float(cfile, n_nodes, max_node_id, &node_id[0], &pos[0, 0],
+                       &angles[0, 0], has_angles);
     fclose(cfile)
 
 

--- a/ansys/mapdl/reader/cython/archive.c
+++ b/ansys/mapdl/reader/cython/archive.c
@@ -53,6 +53,39 @@ int write_nblock(FILE *file, const int n_nodes, const int max_node_id,
 }
 
 
+int write_nblock_float(FILE *file, const int n_nodes, const int max_node_id,
+                       const int *node_id, const float *nodes,
+                       const float *angles, int has_angles){
+  // Header
+  // Tell ANSYS to start reading the node block with 6 fields,
+  // associated with a solid, the maximum node number and the number
+  // of lines in the node block
+  fprintf(file, "/PREP7\n");
+  fprintf(file, "NBLOCK,6,SOLID,%10d,%10d\n", max_node_id, n_nodes);
+  fprintf(file, "(3i8,6e20.13)\n");
+
+  int i;
+  if (has_angles) {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(file,
+              "%8d       0       0%20.12E%20.12E%20.12E%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2],
+              angles[i*3 + 0], angles[i*3 + 1], angles[i*3 + 2]);
+    }
+  }
+  else {
+    for (i=0; i<n_nodes; i++) {
+      fprintf(file,
+              "%8d       0       0%20.12E%20.12E%20.12E\n",
+              node_id[i], nodes[i*3 + 0], nodes[i*3 + 1], nodes[i*3 + 2]);
+    }
+  }
+
+  fprintf(file, "N,R5.3,LOC,       -1,\n");
+  return 0;
+}
+
+
 // Write an ANSYS EBLOCK to file
 int write_eblock(FILE *file,
                  const int n_elem,         // number of elements

--- a/ansys/mapdl/reader/cython/archive.h
+++ b/ansys/mapdl/reader/cython/archive.h
@@ -8,6 +8,8 @@
 
 int write_nblock(FILE*, const int, const int, const int*, const double*,
                  const double*, int);
+int write_nblock_float(FILE*, const int, const int, const int*, const float*,
+                       const float*, int);
 int write_eblock(FILE*, const int, const int*, const int*, const int*,
                  const int*, const int*, const uint8_t*, const int64_t*,
                  const int64_t*, const int*, const int*, const int);


### PR DESCRIPTION
This PR adds support for float32 NBLOCKs in addition to the existing float64 support.

Bumps version to 0.50.4 as 0.50.1 - 0.50.3 break `ansys.mapdl.core` doc builds.
