### PR TITLE
build on numpy<1.20.0 due to binary compatability

### DIFF
--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-reader module."""
 
 # major, minor, patch
-version_info = 0, 50, 4
+version_info = 0, 50, 5
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,4 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy>=1.19.0
+numpy<1.20.0
 cython==0.29.21


### PR DESCRIPTION
Turns out the problem with the `ansys-mapdl-reader` builds for 0.50.1 through 0.50.4 is due to building with ``numpy==1.20.0``.  This seems to be a common issue and moving forward, all builds will be on `numpy<1.20.0` to ensure binary compatibility.

This PR also bumps the version of `ansys-mapdl-reader` to `0.50.5` so we can push out a new version on PyPi and yank the last one.

﻿
