### PR TITLE
Faster element reader

### DIFF
--- a/ansys/mapdl/reader/_version.py
+++ b/ansys/mapdl/reader/_version.py
@@ -1,7 +1,7 @@
 """Version of ansys-mapdl-reader module."""
 
 # major, minor, patch
-version_info = 0, 50, 5
+version_info = 0, 50, 6
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/ansys/mapdl/reader/cython/_archive.pyx
+++ b/ansys/mapdl/reader/cython/_archive.pyx
@@ -6,7 +6,7 @@
 # cython: nonecheck=False
 # cython: embedsignature=True
 
-from libc.stdio cimport fopen, fclose, FILE
+from libc.stdio cimport fopen, fwrite, fclose, FILE, fdopen
 from libc.math cimport abs
 
 import numpy as np
@@ -24,6 +24,11 @@ cdef extern from 'archive.h' nogil:
     int write_eblock(FILE*, const int, const int*, const int*, const int*,
                      const int*, const int*, const uint8_t*, const int64_t*,
                      const int64_t*, const int*, const int*, const int);
+
+
+cdef extern from "stdio.h":
+    FILE *fdopen(int, const char *)
+
 
 
 def py_write_nblock(filename, const int [::1] node_id, int max_node_id,

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -243,7 +243,7 @@ cdef class AnsysFile:
         cdef void* c_ptr
         cdef np.ndarray record 
 
-        # we have no idea the maximum amount of contigious memory we
+        # we have no idea the maximum amount of contiguous memory we
         # need to store the results, so we need to append to a python list
 
         # read element data

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -299,9 +299,6 @@ cdef class AnsysFile:
         cdef void* c_ptr
         cdef np.ndarray record 
 
-        # we have no idea the maximum amount of contiguous memory we
-        # need to store the results, so we need to append to a python list
-
         # read element table index pointer to data
         c_ptr = read_record_fid(self._file, index, &prec_flag,
                                 &type_flag, &size, &bufsize)
@@ -310,9 +307,9 @@ cdef class AnsysFile:
         else:
             ptr = (<int*>c_ptr)[table_index]
 
-        # if ptr <= 0:
-        #     raise ValueError('This element does not have any data associated with the '
-        #                      f' solution_type {solution_type}')
+        if ptr <= 0:
+            raise ValueError('This element does not have any data associated with the '
+                             f' solution_type {solution_type}')
 
         cdef int res = overwriteRecord(self._file, index + ptr, &data[0])
         if res:
@@ -326,9 +323,6 @@ cdef class AnsysFile:
         cdef void* c_ptr
         cdef np.ndarray record 
 
-        # we have no idea the maximum amount of contiguous memory we
-        # need to store the results, so we need to append to a python list
-
         # read element table index pointer to data
         c_ptr = read_record_fid(self._file, index, &prec_flag,
                                 &type_flag, &size, &bufsize)
@@ -337,9 +331,10 @@ cdef class AnsysFile:
         else:
             ptr = (<int*>c_ptr)[table_index]
 
-        # if ptr <= 0:
-        #     raise ValueError('This element does not have any data associated with the '
-        #                      f' solution_type {solution_type}')
+        if ptr <= 0:
+            raise ValueError('This element does not have any data associated with the '
+                             f' solution_type {solution_type}')
+
         print("reading at ", index + ptr)
         cdef int res = overwriteRecordFloat(self._file, index + ptr, &data[0])
         if res:

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -309,7 +309,7 @@ cdef class AnsysFile:
 
         if ptr <= 0:
             raise ValueError('This element does not have any data associated with the '
-                             f' solution_type {solution_type}')
+                             ' solution_type.')
 
         cdef int res = overwriteRecord(self._file, index + ptr, &data[0])
         if res:
@@ -333,7 +333,7 @@ cdef class AnsysFile:
 
         if ptr <= 0:
             raise ValueError('This element does not have any data associated with the '
-                             f' solution_type {solution_type}')
+                             ' solution_type.')
 
         print("reading at ", index + ptr)
         cdef int res = overwriteRecordFloat(self._file, index + ptr, &data[0])

--- a/ansys/mapdl/reader/cython/binary_reader.cpp
+++ b/ansys/mapdl/reader/cython/binary_reader.cpp
@@ -655,17 +655,23 @@ int overwriteRecord(fstream* fs, int ptr, double* data){
   // seek back to right after the header
   fs->seekg(ptr*4 + 8);
 
-  if (type_flag){ // either float or double
-    // TBW
-    // if (prec_flag){  // float
-  } else { // int16 or int32
+  if (type_flag){ // int16 or int32
+    return 1; // type not supported yet
+  } else { // either float or double
     if (prec_flag){  // float
-      size = bufsize / 4;
-      float* float_array[size];
-      std::copy(data, data + size, *float_array);
-      fs->write(reinterpret_cast<const char *>(&float_array), bufsize*sizeof(float));
+      // ideally we'd just copy this all at once
+      // float* float_array[bufsize];  cout << "here" << endl;
+      // std::copy(data, data + bufsize, *float_array);  cout << "here" << endl;
+      // fs->write(reinterpret_cast<const char *>(&float_array), bufsize*sizeof(float));
+
+      // however, this works
+      float val;
+      for (int i=0; i<bufsize; i++){
+        val = (double)(data[i]);
+        fs->write(reinterpret_cast<const char *>(&val), sizeof(float));
+      }
+
     } else {  // must be double
-      size = bufsize / 8;
       fs->write(reinterpret_cast<const char *>(&data), bufsize*sizeof(double));
     }
   }
@@ -695,7 +701,7 @@ int overwriteRecordFloat(fstream* fs, int ptr, float* data){
   // seek back to right after the header
   fs->seekg(ptr*4 + 8);
   if (type_flag){ // either int16 or int32
-    // To be programmed...
+    return 1; // type not supported yet
   } else { // int16 or int32
     if (prec_flag){  // float
       fs->write(reinterpret_cast<const char *>(data), bufsize*sizeof(float));

--- a/ansys/mapdl/reader/cython/binary_reader.cpp
+++ b/ansys/mapdl/reader/cython/binary_reader.cpp
@@ -656,6 +656,9 @@ int overwriteRecord(fstream* fs, int ptr, double* data){
   fs->seekg(ptr*4 + 8);
 
   if (type_flag){ // either float or double
+    // TBW
+    // if (prec_flag){  // float
+  } else { // int16 or int32
     if (prec_flag){  // float
       size = bufsize / 4;
       float* float_array[size];
@@ -665,9 +668,6 @@ int overwriteRecord(fstream* fs, int ptr, double* data){
       size = bufsize / 8;
       fs->write(reinterpret_cast<const char *>(&data), bufsize*sizeof(double));
     }
-  } else { // int16 or int32
-    // TBW
-    // if (prec_flag){  // float
   }
 
   return 0;

--- a/ansys/mapdl/reader/cython/binary_reader.h
+++ b/ansys/mapdl/reader/cython/binary_reader.h
@@ -4,3 +4,4 @@
 void read_nodes(const char*, int64_t, int, int *, double *);
 void* read_record(const char*, int64_t, int*, int*, int*, int*);
 void read_record_stream(std::ifstream*, int64_t, void*, int*, int*, int*);
+void* read_record_fid(std::ifstream*, int64_t, int*, int*, int*, int*);

--- a/ansys/mapdl/reader/cython/binary_reader.h
+++ b/ansys/mapdl/reader/cython/binary_reader.h
@@ -4,4 +4,7 @@
 void read_nodes(const char*, int64_t, int, int *, double *);
 void* read_record(const char*, int64_t, int*, int*, int*, int*);
 void read_record_stream(std::ifstream*, int64_t, void*, int*, int*, int*);
-void* read_record_fid(std::ifstream*, int64_t, int*, int*, int*, int*);
+void* read_record_fid(std::fstream*, int64_t, int*, int*, int*, int*);
+std::fstream* open_fstream(const char*);
+int overwriteRecord(std::fstream*, int, double*);
+int overwriteRecordFloat(std::fstream*, int, float*);

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -1931,10 +1931,12 @@ class Result(AnsysBinary):
                              f' solution_type {solution_type}')
 
         # new c stuff here
-        if data.dtype == np.float32:
+        # if data.dtype == np.float32:
+        if False:
             self._cfile.overwrite_element_data_float(elem_ptr + ptr_off, table_index,
                                                      data)
-        elif data.dtype == np.double:
+        # elif data.dtype == np.double:
+        elif False:
             self._cfile.overwrite_element_data_double(elem_ptr + ptr_off, table_index,
                                                       data)
         else:

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -99,7 +99,7 @@ class Result(AnsysBinary):
         self._cfile = AnsysFile(filename)
         self._resultheader = self._read_result_header()
         self._animating = False
-        self._element_map = None
+        self.__element_map = None
 
         # Get the total number of results and log it
         self.nsets = len(self._resultheader['rpointers'])
@@ -1822,11 +1822,14 @@ class Result(AnsysBinary):
         elemnum = self._eeqv[self._sidx_elem]
         return elemnum, element_stress, enode
 
+    @property
+    def _element_map(self):
+        if self.__element_map is None:
+            self.__element_map = dict(zip(self.mesh.enum, np.arange(self.mesh.n_elem)))
+        return self.__element_map
+
     def element_lookup(self, element_id):
         """Index of the element the element within the result mesh"""
-        if self._element_map is None:
-            self._element_map = dict(zip(self.mesh.enum, np.arange(self.mesh.n_elem)))
-
         try:
             return self._element_map[element_id]
         except KeyError:
@@ -1854,13 +1857,13 @@ class Result(AnsysBinary):
         Parameters
         ----------
         data : list or np.ndarray
-            Data that will replace the record
+            Data that will replace the existing records.
 
         rnum : int
             Zero based result number.
 
         solution_type : str
-            Element data type to retrieve.
+            Element data type to overwrite.
 
             - EMS: misc. data
             - ENF: nodal forces
@@ -1931,68 +1934,179 @@ class Result(AnsysBinary):
                              f' solution_type {solution_type}')
 
         # new c stuff here
-        # if data.dtype == np.float32:
-        if False:
+        if data.dtype == np.float32:
             self._cfile.overwrite_element_data_float(elem_ptr + ptr_off, table_index,
                                                      data)
-        # elif data.dtype == np.double:
-        elif False:
+        elif data.dtype == np.double:
             self._cfile.overwrite_element_data_double(elem_ptr + ptr_off, table_index,
                                                       data)
         else:
-            self._cfile.overwrite_element_data_double(elem_ptr + ptr_off, table_index,
+            # breakpoint()
+            self._cfile.overwrite_element_data_double(elem_ptr + ptr_off,
+                                                      table_index,
                                                       data.astype(np.double))
 
-        py_overwrite = False
-        if py_overwrite:
-            ptr = self.read_record(elem_ptr + ptr_off)[table_index]
-            if ptr <= 0:
-                raise ValueError('This element does not have any data associated with the '
-                                 f' solution_type {solution_type}')
+        ### LEGACY ###
+        # py_overwrite = False
+        # if py_overwrite:
+        #     ptr = self.read_record(elem_ptr + ptr_off)[table_index]
+        #     if ptr <= 0:
+        #         raise ValueError('This element does not have any data associated with the '
+        #                          f' solution_type {solution_type}')
 
-            with open(self.filename, 'r+b') as f:
-                # record size
-                f.seek((ptr_off + elem_ptr + ptr)*4)
-                sz = int.from_bytes(f.read(4), 'little')
+        #     with open(self.filename, 'r+b') as f:
+        #         # record size
+        #         f.seek((ptr_off + elem_ptr + ptr)*4)
+        #         sz = int.from_bytes(f.read(4), 'little')
 
-                # verify data being written is the same size
-                if sz != data.size:
-                    raise ValueError(f'Size of the data being overwritten is {sz}, while '
-                                     f'size of the data input is {data.size}.')
+        #         # verify data being written is the same size
+        #         if sz != data.size:
+        #             raise ValueError(f'Size of the data being overwritten is {sz}, while '
+        #                              f'size of the data input is {data.size}.')
 
-                # verify no compression (8th byte from start of record)
-                f.seek(3, 1)
-                info_byte = f.read(1)
-                compression = access_bit(info_byte, 3) or \
-                    access_bit(info_byte, 4) or \
-                    access_bit(info_byte, 5)
-                # Note: file is now at the start of the data
+        #         # verify no compression (8th byte from start of record)
+        #         f.seek(3, 1)
+        #         info_byte = f.read(1)
+        #         compression = access_bit(info_byte, 3) or \
+        #             access_bit(info_byte, 4) or \
+        #             access_bit(info_byte, 5)
+        #         # Note: file is now at the start of the data
 
-                if compression:
-                    raise RuntimeError('Unable to overwrite this compressed record.  '
-                                       'Please disable result file compression and try '
-                                       'again.')
+        #         if compression:
+        #             raise RuntimeError('Unable to overwrite this compressed record.  '
+        #                                'Please disable result file compression and try '
+        #                                'again.')
 
-                # make input data match data type of the record
-                prec_flag = access_bit(info_byte, 6)
-                type_flag = access_bit(info_byte, 7)
+        #         # make input data match data type of the record
+        #         prec_flag = access_bit(info_byte, 6)
+        #         type_flag = access_bit(info_byte, 7)
 
-                if type_flag:
-                    if prec_flag:
-                        record_dtype = np.int16
-                    else:
-                        record_dtype = np.int32
-                else:
-                    if prec_flag:
-                        record_dtype = np.float32
-                    else:
-                        record_dtype = np.float64
+        #         if type_flag:
+        #             if prec_flag:
+        #                 record_dtype = np.int16
+        #             else:
+        #                 record_dtype = np.int32
+        #         else:
+        #             if prec_flag:
+        #                 record_dtype = np.float32
+        #             else:
+        #                 record_dtype = np.float64
 
-                if data.dtype != record_dtype:
-                    data = data.astype(record_dtype)
+        #         if data.dtype != record_dtype:
+        #             data = data.astype(record_dtype)
 
-                # write the record
-                f.write(data.tobytes())
+        #         # write the record
+        #         f.write(data.tobytes())
+
+    def overwrite_element_solution_records(self, element_data, rnum, solution_type):
+        """Overwrite element solution record.
+
+        This method replaces solution data for a set of elements at a
+        result index for a given solution type.  The number of items
+        in ``data`` must match the number of items in the record.
+
+        If you are not sure how many records are in a given record,
+        use ``element_solution_data`` to retrieve all the records for
+        a given ``solution_type`` and check the number of items in the
+        record.
+
+        Note: The record being replaced cannot be a compressed record.
+        If the result file uses compression (default sparse
+        compression as of 2019R1), you can disable this within MAPDL
+        with:
+        ``/FCOMP, RST, 0``
+
+        Parameters
+        ----------
+        element_data : dict
+            Dictionary of results that will replace the existing records.
+
+        rnum : int
+            Zero based result number.
+
+        solution_type : str
+            Element data type to overwrite.
+
+            - EMS: misc. data
+            - ENF: nodal forces
+            - ENS: nodal stresses
+            - ENG: volume and energies
+            - EGR: nodal gradients
+            - EEL: elastic strains
+            - EPL: plastic strains
+            - ECR: creep strains
+            - ETH: thermal strains
+            - EUL: euler angles
+            - EFX: nodal fluxes
+            - ELF: local forces
+            - EMN: misc. non-sum values
+            - ECD: element current densities
+            - ENL: nodal nonlinear data
+            - EHC: calculated heat generations
+            - EPT: element temperatures
+            - ESF: element surface stresses
+            - EDI: diffusion strains
+            - ETB: ETABLE items
+            - ECT: contact data
+            - EXY: integration point locations
+            - EBA: back stresses
+            - ESV: state variables
+            - MNL: material nonlinear record
+
+        Examples
+        --------
+        Overwrite the elastic strain record for elements 1 and 2 with
+        for the first result with random data.
+
+        >>> from ansys.mapdl import reader as pymapdl_reader
+        >>> rst = pymapdl_reader.read_binary('file.rst')
+        >>> data = {1: np.random.random(56),
+                    2: np.random.random(56)}
+        >>> rst.overwrite_element_solution_data(data, 0, 'EEL')
+        """
+        if not isinstance(element_data, dict):
+            raise TypeError('``element_data`` must be a dictionary')
+
+        table_ptr = solution_type.upper()
+        if table_ptr not in ELEMENT_INDEX_TABLE_KEYS:
+            err_str = 'Data type %s is invalid\n' % str(solution_type)
+            err_str += '\nAvailable types:\n'
+            for key in ELEMENT_INDEX_TABLE_KEYS:
+                err_str += '\t%s: %s\n' % (key, element_index_table_info[key])
+            raise ValueError(err_str)
+
+        if table_ptr in self.available_results._parsed_bits:
+            if table_ptr not in self.available_results:
+                raise ValueError('Result %s is not available in this result file'
+                                 % table_ptr)
+
+        # location of data pointer within each element result table
+        table_index = ELEMENT_INDEX_TABLE_KEYS.index(table_ptr)
+
+        rnum = self.parse_step_substep(rnum)
+        ele_ind_table, nodstr, etype, ptr_off = self._element_solution_header(rnum)
+
+        # index of the element in the element table
+        for element_id, data in element_data.items():
+            if not isinstance(data, np.ndarray):
+                data = np.asarray(data)
+
+            elem_ptr = ele_ind_table[self.element_lookup(element_id)]
+            if elem_ptr == 0:
+                raise ValueError('This element does not have any data associated '
+                                 f'with the solution_type {solution_type}.')
+
+            # new c stuff here
+            if data.dtype == np.float32:
+                self._cfile.overwrite_element_data_float(elem_ptr + ptr_off,
+                                                         table_index, data)
+            elif data.dtype == np.double:
+                self._cfile.overwrite_element_data_double(elem_ptr + ptr_off,
+                                                          table_index, data)
+            else:  # catch-all
+                self._cfile.overwrite_element_data_double(elem_ptr + ptr_off,
+                                                          table_index,
+                                                          data.astype(np.double))
 
     def element_solution_data(self, rnum, datatype, sort=True, **kwargs):
         """Retrieves element solution data.  Similar to ETABLE.

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,4 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy>=1.19.0
+numpy<1.20.0
 cython==0.29.21

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -117,6 +117,30 @@ def test_overwrite(tmpdir):
     assert np.allclose(ovr_record, new_record)
 
 
+def test_overwrite_dict(tmpdir):
+    tmp_path = str(tmpdir.mkdir("tmpdir"))
+    rst = pymapdl_reader.read_binary(copy(examples.rstfile, tmp_path))
+
+    # get the data
+    solution_type = 'EEL'
+    enum, esol_old, _ = rst.element_solution_data(0, solution_type)
+
+    indices = (10, 20)
+    old_records = [esol_old[index] for index in indices]
+
+    element_data = {enum[indices[0]]: np.random.random(old_records[0].size),
+                    enum[indices[1]]: np.random.random(old_records[1].size)}
+
+    rst.overwrite_element_solution_records(element_data, 0, solution_type)
+
+    # verify data has been written
+    new_record = rst.element_solution_data(0, solution_type)[1]
+
+    for i, index in enumerate(indices):
+        assert not np.allclose(old_records[i], new_record[index]), "nothing overwritten"
+        assert np.allclose(element_data[enum[indices[i]]], new_record[index])
+
+
 @pytest.mark.skipif(vm33 is None, reason="Requires example files")
 def test_write_tables(tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join('vm33.txt'))

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -113,6 +113,7 @@ def test_overwrite(tmpdir):
 
     # verify data has been written
     new_record = rst.element_solution_data(0, solution_type)[1][index]
+    assert not np.allclose(new_record, old_record), "nothing overwritten"
     assert np.allclose(ovr_record, new_record)
 
 


### PR DESCRIPTION
This PR improves the performance of the `element_solution_data` method of the `ResultFile` class by 3x and the `overwrite_element_solution_record` by ~ 60x.  Existing solution was inefficient as it opened and closed the file for each read.  In fact, the performance of the entire reader was reduced as the file needed to be opened for each individual record read except for special functions.

Using a `Cython` `AnsysFile` class, it's possible to greatly improve the performance of the reader by keeping the file open as a `ifstream` within ``Cython``.  This lets the file remain open within Python but retail the speed of C++.

Bumps version to ``ansys-mapdl-reader==0.50.6``.