### PR TITLE
Replace deprecated `numpy.float` by `numpy.float64`

### DIFF
--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -1396,7 +1396,7 @@ class Result(AnsysBinary):
         # Node information
         nnod = self._geometry_header['nnod']
         nnum = np.empty(nnod, np.int32)
-        nodes = np.empty((nnod, 6), np.float)
+        nodes = np.empty((nnod, 6), np.float64)
         _binary_reader.load_nodes(self.filename, self._geometry_header['ptrLOC'],
                                   nnod, nodes, nnum)
 

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -352,4 +352,4 @@ def test_reaction_forces(volume_rst):
     rforces, nnum, dof = volume_rst.nodal_reaction_forces(0)
     assert (np.diff(nnum) >= 0).all()
     assert (np.in1d(dof, [1, 2, 3])).all()
-    assert rforces.dtype == np.float
+    assert rforces.dtype == np.float64


### PR DESCRIPTION
Hi everybody,

since this fabulous tool has become of my daily work routine, it is also run within the pytest matrix of our own modules under development.
One small thing that I found, is that there are some places where the deprecated datatype `numpy.float` is being used. This leads to warning raised by pytest.
Nothing to worry too much about, still it would be nice to get rid of these.