### PR TITLE
Hotfix: Output node numbers in nodal_reaction_forces

### DIFF
--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -326,7 +326,6 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
     >>> pymapdl_reader.save_as_archive('archive.cdb', grid)
 
     """
-
     if isinstance(grid, pv.PolyData):
         grid = grid.cast_to_unstructured_grid()
 

--- a/ansys/mapdl/reader/common.py
+++ b/ansys/mapdl/reader/common.py
@@ -110,35 +110,6 @@ class AnsysBinary():
         record = c_read_record(self.filename, pointer, return_bufsize)
         return record
 
-    # def read_record(self, pointer, return_bufsize=False):
-    #     """Reads a record at a given position.
-
-    #     Because ANSYS 19.0+ uses compression by default, you must use
-    #     this method rather than ``np.fromfile``.
-
-    #     Parameters
-    #     ----------
-    #     pointer : int
-    #         ANSYS file position (n words from start of file).  A word
-    #         is four bytes.
-
-    #     return_bufsize : bool, optional
-    #         Returns the number of words read (includes header and
-    #         footer).  Useful for determining the new position in the
-    #         file after reading a record.
-
-    #     Returns
-    #     -------
-    #     record : np.ndarray
-    #         The record read as a ``n x 1`` numpy array.
-
-    #     bufsize : float, optional
-    #         When ``return_bufsize`` is enabled, returns the number of
-    #         words read.
-
-    #     """
-    #     return c_read_record(self.filename, pointer, return_bufsize)
-
 
 def read_binary(filename, **kwargs):
     """Reads ANSYS-written binary files:

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -1446,6 +1446,44 @@ class Result(AnsysBinary):
         header : dict
             Double precision solution header data.
 
+        Examples
+        --------
+        Extract the solution info from a sample example result file.
+
+        >>> from ansys.mapdl.reader import examples
+        >>> rst = examples.download_pontoon()
+        >>> rst.solution_info(0)
+        {'cgcent': [],
+         'fatjack': [],
+         'timfrq': 44.85185724963714,
+         'lfacto': 1.0,
+         'lfactn': 1.0,
+         'cptime': 3586.4873046875,
+         'tref': 71.6,
+         'tunif': 71.6,
+         'tbulk': 293.0,
+         'volbase': 0.0,
+         'tstep': 0.0,
+         '__unused': 0.0,
+         'accel_x': 0.0,
+         'accel_y': 0.0,
+         'accel_z': 0.0,
+         'omega_v_x': 0.0,
+         'omega_v_y': 0.0,
+         'omega_v_z': 0.0,
+         'omega_a_x': 0.0,
+         'omega_a_y': 0.0,
+         'omega_a_z': 0.0,
+         'omegacg_v_x': 0.0,
+         'omegacg_v_y': 0.0,
+         'omegacg_v_z': 0.0,
+         'omegacg_a_x': 0.0,
+         'omegacg_a_y': 0.0,
+         'omegacg_a_z': 0.0,
+         'dval1': 0.0,
+         'pCnvVal': 0.0}
+
+
         Notes
         -----
         The keys of the solution header are described below:
@@ -1478,7 +1516,7 @@ class Result(AnsysBinary):
         # convert to cumulative index
         rnum = self.parse_step_substep(rnum)
 
-        # skip pointers table
+        # skip solution data header
         ptr = self._resultheader['rpointers'][rnum]
         _, sz = self.read_record(ptr, True)
 

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -3281,7 +3281,7 @@ class Result(AnsysBinary):
         Returns
         -------
         rforces : np.ndarray
-            Reaction Forces
+            Nodal reaction forces.
 
         nnum : np.ndarray
             Node numbers corresponding to the reaction forces.  Does
@@ -3352,7 +3352,8 @@ class Result(AnsysBinary):
             dof = dof[sidx]
             rforces = rforces[sidx]
 
-        return rforces, index, dof
+        nnum = self._mesh.nnum[index]
+        return rforces, nnum, dof
 
     def plot_element_result(self, rnum, result_type, item_index,
                             in_element_coord_sys=False, **kwargs):

--- a/tests/test_binary_reader.py
+++ b/tests/test_binary_reader.py
@@ -20,6 +20,10 @@ try:
 except:
     _HAS_ANSYS = False
 
+if os.environ.get('SKIP_ANSYS', '').upper() == 'TRUE':
+    _HAS_ANSYS = False
+
+
 HAS_FFMPEG = True
 try:
     import imageio_ffmpeg

--- a/tests/test_dist_rst.py
+++ b/tests/test_dist_rst.py
@@ -11,20 +11,23 @@ from ansys.mapdl.reader.dis_result import DistributedResult
 from ansys.mapdl.reader._rst_keys import element_index_table_info
 
 try:
+    from ansys.mapdl.core import _HAS_ANSYS
     from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
     # from ansys.mapdl.core.mapdl_corba import MapdlCorba
     MapdlCorba = None
     from ansys.mapdl.core.mapdl_console import MapdlConsole
-    from ansys.mapdl.core import _HAS_ANSYS as HAS_ANSYS
 except:
-    HAS_ANSYS = False
+    _HAS_ANSYS = False
+
+if os.environ.get('SKIP_ANSYS', '').upper() == 'TRUE':
+    _HAS_ANSYS = False
 
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 testfiles_path = os.path.join(test_path, 'testfiles')
 
 
-skip_no_ansys = pytest.mark.skipif(not HAS_ANSYS, reason="Requires ANSYS installed")
+skip_no_ansys = pytest.mark.skipif(not _HAS_ANSYS, reason="Requires ANSYS installed")
 
 
 @pytest.fixture()


### PR DESCRIPTION
Minor bugfix to output node numbers in ``nodal_reaction_forces``.

Commits:

- misc cleanup and example for solution_info
- add env var to skip MAPDL testing
- output node numbers in nodal_reaction_forces
