### PR TITLE
Fix max element types

### DIFF
--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -254,9 +254,9 @@ cdef class AnsysFile:
         del self._file
         del self._file_out
 
-    def read_element_data(self, int64_t [::1] ele_ind_table, int table_index, int ptr_off):
-        cdef int64_t ind
-        cdef int ptr
+    def read_element_data(self, int64_t [::1] ele_ind_table, int table_index,
+                          int64_t ptr_off):
+        cdef int64_t ind, ptr
         cdef int prec_flag, type_flag, size, bufsize
         cdef void* c_ptr
         cdef np.ndarray record 

--- a/ansys/mapdl/reader/mesh.py
+++ b/ansys/mapdl/reader/mesh.py
@@ -118,8 +118,8 @@ class Mesh():
             etype_map[allowable_types] = ETYPE_MAP[allowable_types]
 
         # ANSYS element type to VTK map
-        type_ref = np.empty(2 << 15, np.int32)  # 65536
-        type_ref[self._ekey[:, 0]] = etype_map[self._ekey[:, 1]]        
+        type_ref = np.empty(2 << 16, np.int32)  # 131072
+        type_ref[self._ekey[:, 0]] = etype_map[self._ekey[:, 1]]
 
         # special treatment for MESH200
         if allowable_types is None or 200 in allowable_types:

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -1339,9 +1339,9 @@ class Result(AnsysBinary):
         e_type_table, sz = self.read_record(ptrety, True)
 
         # store information for each element type
-        nodelm = np.empty(10000, np.int32)  # n nodes for this element type
-        nodfor = np.empty(10000, np.int32)  # n nodes per element having nodal forces
-        nodstr = np.empty(10000, np.int32)  # n nodes per element having nodal stresses
+        nodelm = {}  # n nodes for this element type
+        nodfor = {}  # n nodes per element having nodal forces
+        nodstr = {}  # n nodes per element having nodal stresses
         ekey = []
         keyopts = np.zeros((10000, 11), np.int16)
 
@@ -1385,10 +1385,23 @@ class Result(AnsysBinary):
                 if keyopts[etype_ref, 7] == 0:
                     nodstr[etype_ref] *= 2
 
+        def dict_to_arr(index_dict):
+            """Convert an index dictionary to an array
+
+            For example:
+            {1: 20, 2: 30} --> [UNDEF, 20, 30]
+
+            """
+            arr = np.empty(max(index_dict.keys()) + 1, np.int32)
+            for key, value in index_dict.items():
+                arr[key] = value
+            return arr
+
+        # rest of pymapdl-reader expects the following as arrays.
         # store element table data
-        return {'nodelm': nodelm,
-                'nodfor': nodfor,
-                'nodstr': nodstr,
+        return {'nodelm': dict_to_arr(nodelm),
+                'nodfor': dict_to_arr(nodfor),
+                'nodstr': dict_to_arr(nodstr),
                 'keyopts': keyopts,
                 'ekey': np.array(ekey)}
 

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -1343,7 +1343,7 @@ class Result(AnsysBinary):
         nodfor = {}  # n nodes per element having nodal forces
         nodstr = {}  # n nodes per element having nodal stresses
         ekey = []
-        keyopts = np.zeros((10000, 11), np.int16)
+        keyopts = {}  # key options
 
         # Assemble element record pointers relative to ptrETY
         if self._map_flag:
@@ -1382,7 +1382,7 @@ class Result(AnsysBinary):
             #
             # Only valid for SHELL181 or SHELL281 elements.
             if einfo[1] == 181 or einfo[1] == 281:
-                if keyopts[etype_ref, 7] == 0:
+                if keyopts[etype_ref][7] == 0:
                     nodstr[etype_ref] *= 2
 
         def dict_to_arr(index_dict):


### PR DESCRIPTION
This PR resolves #31 by implementing dynamically sized arrays for element information.  This solves the problem of large element type numbers by using dictionaries rather than statically sized arrays.

Commits:
- use dict for element info sizing
- use dict for keyopts
