### PR TITLE
require matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.14.0
 pyvista>=0.27.2
 appdirs>=1.4.0
 tqdm>=4.45.0
+matplotlib>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ with io_open(version_file, mode='r') as fd:
 install_requires = ['numpy>=1.14.0',
                     'pyvista>=0.30.1',
                     'appdirs>=1.4.0',
+                    'matplotlib>=3.0',
                     'tqdm>=4.45.0']
 
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ with io_open(version_file, mode='r') as fd:
 install_requires = ['numpy>=1.14.0',
                     'pyvista>=0.30.1',
                     'appdirs>=1.4.0',
-                    'matplotlib',
+                    'matplotlib>=3.0.0',
                     'tqdm>=4.45.0']
 
 

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ with io_open(version_file, mode='r') as fd:
 install_requires = ['numpy>=1.14.0',
                     'pyvista>=0.30.1',
                     'appdirs>=1.4.0',
-                    'matplotlib>=3.0',
+                    'matplotlib',
                     'tqdm>=4.45.0']
 
 


### PR DESCRIPTION
Due to changes with `pyvista==0.31.0`, we now need to include `matplotlib` as a dependency.
