### PR TITLE
check py38 and 64 bit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Installation file for ansys-mapdl-reader"""
+import struct
 import os
 import sys
 from io import open as io_open
@@ -88,6 +89,25 @@ install_requires = ['numpy>=1.14.0',
                     'appdirs>=1.4.0',
                     'matplotlib>=3.0.0',
                     'tqdm>=4.45.0']
+
+# perform python version checking
+# this is necessary to avoid the new pip package checking as vtk does
+# not support Python 3.9 or any 32-bit as of 17 June 2021.
+is64 = struct.calcsize("P")*8 == 64
+if not is64:
+    raise RuntimeError('\n\n``ansys-mapdl-reader`` requires 64-bit Python\n'
+                       'Please check the version of Python installed at\n'
+                       '%s' % sys.executable)
+
+if sys.version_info.minor > 8:
+    try:
+        import vtk
+    except:
+        raise RuntimeError('\n\n``ansys-mapdl-reader`` supports Python 3.6 - 3.8\n'
+                           'Python 3.9 support depends on vtk wheels, which should\n'
+                           'be released by August 2021.\n\n'
+                           'Installed Python:\n'
+                           '%s' % str(sys.version.splitlines()[0]))
 
 
 # Actual setup


### PR DESCRIPTION
Due to updates with `pip`, users can get into a near endless install 
when trying to `pip install ansys-mapdl-core`.  Setup now performs 
basic checks to verify python version (i.e. 64 bit < Python 3.8)
﻿
