### PR TITLE
optimize import by loading subset from vtk

### DIFF
--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -5,11 +5,14 @@ import logging
 from functools import wraps
 
 import numpy as np
-from vtk import (VTK_TETRA, VTK_QUADRATIC_TETRA, VTK_PYRAMID,
-                 VTK_QUADRATIC_PYRAMID, VTK_WEDGE, VTK_QUADRATIC_WEDGE,
-                 VTK_HEXAHEDRON, VTK_QUADRATIC_HEXAHEDRON, VTK_TRIANGLE, VTK_QUAD,
-                 VTK_QUADRATIC_TRIANGLE, VTK_QUADRATIC_QUAD)
-import vtk
+from pyvista._vtk import (VTK_TETRA, VTK_QUADRATIC_TETRA, VTK_PYRAMID,
+                          VTK_QUADRATIC_PYRAMID, VTK_WEDGE,
+                          VTK_QUADRATIC_WEDGE, VTK_HEXAHEDRON,
+                          VTK_QUADRATIC_HEXAHEDRON, VTK_TRIANGLE,
+                          VTK_QUAD, VTK_QUADRATIC_TRIANGLE,
+                          VTK_QUADRATIC_QUAD)
+from pyvista import _vtk as vtk
+from pyvista._vtk import VTK9
 import pyvista as pv
 
 from ansys.mapdl.reader import _reader, _archive
@@ -17,7 +20,6 @@ from ansys.mapdl.reader.misc import vtk_cell_info, chunks
 from ansys.mapdl.reader.mesh import Mesh
 from ansys.mapdl.reader.cell_quality import quality
 
-VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
 
 log = logging.getLogger(__name__)
 log.setLevel('CRITICAL')

--- a/ansys/mapdl/reader/cell_quality.py
+++ b/ansys/mapdl/reader/cell_quality.py
@@ -4,7 +4,6 @@ cell quality from VTK unstructured grids.
 import numpy as np
 import pyvista as pv
 
-from ansys.mapdl.reader._cellqual import cell_quality_float, cell_quality
 from ansys.mapdl.reader.misc import vtk_cell_info
 
 
@@ -32,6 +31,10 @@ def quality(grid):
     array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
            1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])
     """
+
+    # lazy load to speed up import
+    from ansys.mapdl.reader._cellqual import cell_quality_float, cell_quality
+
     flip = False
     if isinstance(grid, pv.StructuredGrid):
         grid = grid.cast_to_unstructured_grid()

--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -1,7 +1,7 @@
 """Supports reading cyclic structural result files from ANSYS"""
 from functools import wraps
 
-from vtk import vtkMatrix4x4, vtkTransform, vtkAppendFilter
+from pyvista._vtk import vtkMatrix4x4, vtkTransform, vtkAppendFilter
 import numpy as np
 import pyvista as pv
 

--- a/ansys/mapdl/reader/dis_result.py
+++ b/ansys/mapdl/reader/dis_result.py
@@ -6,7 +6,7 @@ from functools import wraps
 
 import pyvista as pv
 import numpy as np
-from vtk import vtkAppendFilter
+from pyvista._vtk import vtkAppendFilter
 
 from ansys.mapdl.reader.misc import is_float, vtk_cell_info
 from ansys.mapdl.reader.mesh import Mesh

--- a/ansys/mapdl/reader/mesh.py
+++ b/ansys/mapdl/reader/mesh.py
@@ -1,6 +1,7 @@
 """Module for common class between Archive, and result mesh"""
 import pyvista as pv
-import vtk
+from pyvista import _vtk as vtk
+from pyvista._vtk import VTK9
 import numpy as np
 
 from ansys.mapdl.reader import _relaxmidside, _reader
@@ -8,7 +9,6 @@ from ansys.mapdl.reader.misc import unique_rows
 from ansys.mapdl.reader.elements import ETYPE_MAP
 
 
-VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
 INVALID_ALLOWABLE_TYPES = TypeError('`allowable_types` must be an array '
                                     'of ANSYS element types from 1 and 300')
 

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -9,9 +9,9 @@ import warnings
 from threading import Thread
 from functools import wraps
 
-import vtk
 import numpy as np
 import pyvista as pv
+from pyvista import _vtk as vtk
 from tqdm import tqdm
 
 from ansys.mapdl.reader import _binary_reader, _reader
@@ -35,8 +35,6 @@ from ansys.mapdl.reader.common import (read_table, parse_header,
                                        THERMAL_STRAIN_TYPES)
 from ansys.mapdl.reader.misc import vtk_cell_info, break_apart_surface
 from ansys.mapdl.reader.rst_avail import AvailableResults
-
-VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
 
 
 def access_bit(data, num):

--- a/setup.py
+++ b/setup.py
@@ -92,12 +92,14 @@ install_requires = ['numpy>=1.14.0',
 
 # perform python version checking
 # this is necessary to avoid the new pip package checking as vtk does
-# not support Python 3.9 or any 32-bit as of 17 June 2021.
-is64 = struct.calcsize("P")*8 == 64
-if not is64:
-    raise RuntimeError('\n\n``ansys-mapdl-reader`` requires 64-bit Python due to vtk.\n'
-                       'Please check the version of Python installed at\n'
-                       '%s' % sys.executable)
+# not support Python 32-bit as of 17 June 2021.
+if not struct.calcsize("P")*8 == 64:
+    try:
+        import vtk
+    except ImportError:
+        raise RuntimeError('\n\n``ansys-mapdl-reader`` requires 64-bit Python due to vtk.\n'
+                           'Please check the version of Python installed at\n'
+                           '%s' % sys.executable)
 
 # Actual setup
 setup(


### PR DESCRIPTION
Minor PR to reduce the number of vtk libraries loaded by default from vtk by using ``pyvista._vtk``. 
