### PR TITLE
Result._plot_point_scalars: Use argument return_cpos in any case and fix screenshot function on Windows OS 

### DIFF
--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -2754,7 +2754,7 @@ class Result(AnsysBinary):
 
         # camera position added in 0.32.0
         show_kwargs = {}
-        if pv._version.version_info[1] > 31:
+        if pv._version.version_info >= (0, 32, 0):
             show_kwargs['return_cpos'] = return_cpos
 
         if animate:


### PR DESCRIPTION
1. **Use argument return_cpos in any case**: before, it was used only, when `if animate`. Now, it used in any case of the call `plotter.show`. I tested the changes of 56f38f1 on Windows 10.
2. **Fix screenshot function on Windows OS:** pyvista\plotting\plotting.py:4882: On Windows OS "in the event that the user hits the exit-button on the GUI then it must be finalized and deleted as accessing it will kill the kernel... proper screenshots cannot be saved if this happens". Therefore, when you used `_plot_point_scalars(..., screenshot=...)`, you got at ansys\mapdl\reader\rst.py:2830: `RuntimeError: This plotter is closed and unable to save a screenshot.`
The only solution is, to pass the `screenshot` argument to `plotter.show` as done in the commit d5ad42d.
3. **Future-safe pyvista version check**: the old version check would break with version 1.0.0, commit 1c00879.