### PR TITLE
cython._binary_reader: cells_with_*_nodes: Generalize and simplify by directly using `offset` for next cell offset; close: `_file_out` does not exist; correct pyvista version check for version 0.32.dev0

### DIFF
--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -252,7 +252,6 @@ cdef class AnsysFile:
     def close(self):
         """Close the file"""
         del self._file
-        del self._file_out
 
     def read_element_data(self, int64_t [::1] ele_ind_table, int table_index,
                           int64_t ptr_off):

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -1644,7 +1644,7 @@ def cells_with_all_nodes(index_type [::1] offset, index_type [::1] cells,
     Updates mask of cells containing all points in the point indices
     or mask.
     """
-    cdef int ncells = offset - 1
+    cdef int ncells = offset.size - 1
     cdef int i, j
     cdef index_type cell_offset, next_cell_offset
     cdef uint8 [::1] cell_mask = np.ones(ncells, np.uint8)
@@ -1666,7 +1666,7 @@ def cells_with_any_nodes(index_type [::1] offset, index_type [::1] cells,
     Updates mask of cells containing at least one point in the point
     indices or mask.
     """
-    cdef int ncells = offset - 1
+    cdef int ncells = offset.size - 1
     cdef index_type cell_offset, next_cell_offset
     cdef int i, j
 

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -1638,35 +1638,22 @@ def affline_transform(float_or_double [:, ::1] points, float_or_double [:, ::1] 
         points[i, 2] = t20*x + t21*y + t22*z + t23
 
 
-cdef inline int cell_lookup(uint8 celltype) nogil:
-    if celltype == VTK_HEXAHEDRON or celltype == VTK_QUADRATIC_HEXAHEDRON:
-        return 8
-    elif celltype == VTK_TETRA or celltype == VTK_QUADRATIC_TETRA:
-        return 4
-    elif celltype == VTK_PYRAMID or celltype == VTK_QUADRATIC_PYRAMID:
-        return 5
-    elif celltype == VTK_WEDGE or celltype == VTK_QUADRATIC_WEDGE:
-        return 6
-
-
 def cells_with_all_nodes(index_type [::1] offset, index_type [::1] cells,
-                         uint8 [::1] celltypes, uint8 [::1] point_mask):
+                         uint8 [::1] point_mask):
     """
     Updates mask of cells containing all points in the point indices
     or mask.
     """
-    cdef int ncells = celltypes.size
-    cdef uint8 celltype
-    cdef int ncell_points, i, j
-    cdef index_type cell_offset
+    cdef int ncells = offset - 1
+    cdef int i, j
+    cdef index_type cell_offset, next_cell_offset
     cdef uint8 [::1] cell_mask = np.ones(ncells, np.uint8)
 
     with nogil:
         for i in range(ncells):
-            celltype = celltypes[i]
-            ncell_points = cell_lookup(celltype)
             cell_offset = offset[i] + 1
-            for j in range(cell_offset, cell_offset + ncell_points):
+            next_cell_offset = offset[i+1] + 1
+            for j in range(cell_offset, next_cell_offset):
                 if point_mask[cells[j]] != 1:
                     cell_mask[i] = 0
 
@@ -1674,25 +1661,22 @@ def cells_with_all_nodes(index_type [::1] offset, index_type [::1] cells,
 
 
 def cells_with_any_nodes(index_type [::1] offset, index_type [::1] cells,
-                         uint8 [::1] celltypes, uint8 [::1] point_mask):
+                         uint8 [::1] point_mask):
     """
     Updates mask of cells containing at least one point in the point
     indices or mask.
     """
-    cdef int ncells = celltypes.size
-    cdef uint8 celltype
-    cdef int ncell_points
-    cdef index_type cell_offset
+    cdef int ncells = offset - 1
+    cdef index_type cell_offset, next_cell_offset
     cdef int i, j
 
     cdef uint8 [::1] cell_mask = np.zeros(ncells, np.uint8)
 
     with nogil:
         for i in range(ncells):
-            celltype = celltypes[i]
-            ncell_points = cell_lookup(celltype)
             cell_offset = offset[i] + 1
-            for j in range(cell_offset, cell_offset + ncell_points):
+            next_cell_offset = offset[i+1] + 1
+            for j in range(cell_offset, next_cell_offset):
                 if point_mask[cells[j]] == 1:
                     cell_mask[i] = 1
                     break

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -2819,21 +2819,18 @@ class Result(AnsysBinary):
             plotter.close()
             cpos = plotter.camera_position
 
-        elif screenshot:
-            cpos = plotter.show(auto_close=False, interactive=interactive,
-                                window_size=window_size,
-                                full_screen=full_screen,
-                                **show_kwargs)
-            if screenshot is True:
-                img = plotter.screenshot()
-            else:
-                plotter.screenshot(screenshot)
-            plotter.close()
+        elif screenshot is True:
+            cpos, img = plotter.show(interactive=interactive,
+                                     window_size=window_size,
+                                     full_screen=full_screen,
+                                     screenshot=screenshot,
+                                     **show_kwargs)
 
         else:
             cpos = plotter.show(interactive=interactive,
                                 window_size=window_size,
                                 full_screen=full_screen,
+                                screenshot=screenshot,
                                 **show_kwargs)
 
         if screenshot is True:

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -723,10 +723,10 @@ class Result(AnsysBinary):
         # need to extract the mesh
         cells, offset = vtk_cell_info(grid)
         if sel_type_all:
-            cell_mask = cells_with_all_nodes(offset, cells, grid.celltypes,
+            cell_mask = cells_with_all_nodes(offset, cells,
                                              mask.view(np.uint8))
         else:
-            cell_mask = cells_with_any_nodes(offset, cells, grid.celltypes,
+            cell_mask = cells_with_any_nodes(offset, cells,
                                              mask.view(np.uint8))
 
         if not cell_mask.any():

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -2754,7 +2754,7 @@ class Result(AnsysBinary):
 
         # camera position added in 0.32.0
         show_kwargs = {}
-        if pv._version.version_info[1] > 31:
+        if pv._version.version_info >= (0, 32, 0):
             show_kwargs['return_cpos'] = return_cpos
 
         if animate:

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -2752,6 +2752,11 @@ class Result(AnsysBinary):
             result_text = self.text_result_table(rnum)
             plotter.add_text(result_text, font_size=20, color=text_color)
 
+        # camera position added in 0.32.0
+        show_kwargs = {}
+        if pv._version.version_info[1] > 31:
+            show_kwargs['return_cpos'] = return_cpos
+
         if animate:
             if off_screen:  # otherwise this never exits
                 loop = False
@@ -2760,11 +2765,6 @@ class Result(AnsysBinary):
                 pbar = tqdm(total=n_frames, desc='Rendering animation')
 
             orig_pts = copied_mesh.points.copy()
-
-            # camera position added in 0.32.0
-            show_kwargs = {}
-            if pv._version.version_info[1] > 31:
-                show_kwargs['return_cpos'] = return_cpos
 
             plotter.show(interactive=False, auto_close=False,
                          window_size=window_size,
@@ -2822,7 +2822,8 @@ class Result(AnsysBinary):
         elif screenshot:
             cpos = plotter.show(auto_close=False, interactive=interactive,
                                 window_size=window_size,
-                                full_screen=full_screen)
+                                full_screen=full_screen,
+                                **show_kwargs)
             if screenshot is True:
                 img = plotter.screenshot()
             else:
@@ -2832,7 +2833,8 @@ class Result(AnsysBinary):
         else:
             cpos = plotter.show(interactive=interactive,
                                 window_size=window_size,
-                                full_screen=full_screen)
+                                full_screen=full_screen,
+                                **show_kwargs)
 
         if screenshot is True:
             return cpos, img

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -2754,7 +2754,7 @@ class Result(AnsysBinary):
 
         # camera position added in 0.32.0
         show_kwargs = {}
-        if pv._version.version_info >= (0, 32, 0):
+        if pv._version.version_info >= (0, 32):
             show_kwargs['return_cpos'] = return_cpos
 
         if animate:


### PR DESCRIPTION
## Fixes of cython._binary_reader

1. **cells_with_*_nodes: Generalize and simplify by directly using `offset` for next cell offset**
    - Therefore the function `cell_lookup`, which was limited to 3D cells, is no longer necessary.
    - Now, all cell types are supported, while the functions has even been simplified.
    - Now, the functions do not need the parameter `celltypes` any more. Since they are only used in rst.py in the private method `Result._extract_node_components`, I took the liberty to remove the parameter `celltypes` in the respective definition and the respective call.
    - This commit 62edb6a is written with minimal changes for a clear diff. Of course, one could optimize the speed by omitting the double call of `offset[i+1]` first and `offset[i]` in the next loop step.
    - **Sorry**: I make a mistake in commit 62edb6a (I can not compile locally, as a have no C++ compiler installed), ae3a88e is needed to correct this.

2. **close: `_file_out` does not exist**: When you called `AnsysFile.close()` you got at line 255 `del self._file_out`: `'ansys.mapdl.reader._binary_reader.AnsysFile' object has no attribute '_file_out'` as `_file_out` is never created (this line is the only occurrence). Thus, I removed this line in commit 1c6351e.

**Remark:** Only tested with a pure python version of the functions, please test the cython functions of this commit!

## Fix of Result._plot_point_scalars (improvement for 1c00879)

3.  **Result._plot_point_scalars: correct pyvista version check for version 0.32.dev0**: The actual development version is 0.32.dev0: `pv._version.version_info = (0, 32, "dev0")`. There, the string `"dev0"` can not be compared with `0`, so that comparison failed for this version. I removed the last element on the right-hand side expression of the comparison to solve this. Now, the new comparison `(0, 32, "dev0") > (0, 32)` works as expected. Commit 3f6e296 was tested manually.