### PR TITLE
fix autoclose bug for vtk 9.1.0

### DIFF
--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -1921,13 +1921,6 @@ class CyclicResult(Result):
         if cpos is not None:
             plotter.camera_position = cpos
 
-        if screenshot:
-            cpos = plotter.show(auto_close=False,
-                                window_size=window_size,
-                                full_screen=full_screen)
-            plotter.screenshot(screenshot)
-            plotter.close()
-        else:
-            cpos = plotter.show(window_size=window_size, full_screen=full_screen)
-
-        return cpos
+        return plotter.show(
+            screenshot=screenshot, window_size=window_size, full_screen=full_screen
+        )


### PR DESCRIPTION
This PR corrects the segfault identified when using `auto_close=False` on Windows. when using the latest release (9.1.0) of VTK.