### PR TITLE
fix edge case for cmblock when sized as a multiple of 8

### DIFF
--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -605,19 +605,14 @@ def write_cmblock(filename, items, comp_name, comp_type,
     ----------
     filename : str or file handle
         File to write CMBLOCK component to.
-
     items : list or np.ndarray
         Element or node numbers to write.
-
     comp_name : str
         Name of the component
-
     comp_type : str
         Component type to write.  Should be either 'ELEMENT' or 'NODE'.
-
     digit_width : int, optional
         Default 10
-
     mode : str, optional
         Write mode.  Default ``'w'``.
     """
@@ -650,11 +645,15 @@ def write_cmblock(filename, items, comp_name, comp_type,
     # writing each line.
     # nearest multiple of 8
     up_to = len(cmblock_items) % 8
-    np.savetxt(fid, cmblock_items[:-up_to].reshape(-1, 8), digit_formatter*8)
+    if up_to:  # deal with the zero case
+        np.savetxt(fid, cmblock_items[:-up_to].reshape(-1, 8), digit_formatter*8)
 
-    # write the final line
-    chunk = cmblock_items[-up_to:]
-    print(''.join([digit_formatter] * len(chunk)) % tuple(chunk), file=fid)
+        # write the final line
+        chunk = cmblock_items[-up_to:]
+        print(''.join([digit_formatter] * len(chunk)) % tuple(chunk), file=fid)
+    else:
+        np.savetxt(fid, cmblock_items.reshape(-1, 8), digit_formatter*8)
+
     print('', file=fid)
 
     if opened_file:
@@ -662,8 +661,8 @@ def write_cmblock(filename, items, comp_name, comp_type,
 
 
 def _write_eblock(filename, elem_id, etype, mtype, rcon, elem_nnodes,
-                 cells, offset, celltypes, typenum,
-                 nodenum, mode='a'):
+                  cells, offset, celltypes, typenum,
+                  nodenum, mode='a'):
     """Write EBLOCK to disk"""
     # perform type checking here
     if elem_id.dtype != np.int32:

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -318,6 +318,16 @@ def test_write_component(tmpdir):
     assert np.allclose(archive.node_components[comp_name], items)
 
 
+def test_write_component_edge_case(tmpdir):
+    items = np.arange(2, 34, step=2)
+    filename = str(tmpdir.mkdir("tmpdir").join('tmp.cdb'))
+
+    comp_name = 'TEST'
+    pymapdl_reader.write_cmblock(filename, items, comp_name, 'node')
+    archive = pymapdl_reader.Archive(filename)
+    assert np.allclose(archive.node_components[comp_name], items)
+
+
 def test_read_parm():
     filename = os.path.join(TESTFILES_PATH, 'parm.cdb')
     archive = pymapdl_reader.Archive(filename)


### PR DESCRIPTION
Resolve #67 by fixing the edge case when the CMBLOCK entries are a multiple of 8.
