### PR TITLE
fix empty grid edge case

### DIFF
--- a/ansys/mapdl/reader/mesh.py
+++ b/ansys/mapdl/reader/mesh.py
@@ -184,11 +184,13 @@ class Mesh():
             grid = grid.extract_cells(grid.celltypes != 0)
 
         if force_linear:
-            grid = grid.linear_copy()
+            # only run if the grid has points or cells
+            if grid.n_points:
+                grid = grid.linear_copy()
 
         # map over element types
         # Add tracker for original node numbering
-        ind = np.arange(grid.number_of_points)
+        ind = np.arange(grid.n_points)
         grid.point_data['origid'] = ind
         grid.point_data['VTKorigID'] = ind
         return grid

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class build_ext(_build_ext):
                     if platform.system() == 'Darwin':
                         # get the minor version
                         mac_version, _, _ = platform.mac_ver()
-                        minor = mac_version.split('.')[1]
+                        minor = [int(n) for n in mac_version.split('.')][1]
 
                         # libstdc++ is deprecated in recent versions of XCode
                         if minor >= 9:

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,9 @@ class build_ext(_build_ext):
                     e.extra_compile_args.append('-stdlib=libc++')
 
                     if platform.system() == 'Darwin':
+                        # get the minor version
                         mac_version, _, _ = platform.mac_ver()
-                        major, minor, patch = [int(n) for n in mac_version.split('.')]
+                        minor = mac_version.split('.')[1]
 
                         # libstdc++ is deprecated in recent versions of XCode
                         if minor >= 9:


### PR DESCRIPTION
This PR adds in a basic guard against trying to perform a `linear_copy` on an empty grid. Prior to the this check the error was confusing.
