### PR TITLE
vtk parse in mesh import can be switched off

### DIFF
--- a/ansys/mapdl/reader/common.py
+++ b/ansys/mapdl/reader/common.py
@@ -180,7 +180,8 @@ def read_binary(filename, **kwargs):
             return CyclicResult(filename)
 
         if read_mesh:
-            result._store_mesh()
+            flag_vtk_parse = kwargs.pop('flag_vtk_parse', True)
+            result._store_mesh(flag_vtk_parse)
 
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class build_ext(_build_ext):
 
                     if platform.system() == 'Darwin':
                         mac_version, _, _ = platform.mac_ver()
-                        major, minor, patch = [int(n) for n in mac_version.split('.')]
+                        minor = [int(n) for n in mac_version.split('.')][1]
 
                         # libstdc++ is deprecated in recent versions of XCode
                         if minor >= 9:


### PR DESCRIPTION
added flag to (optionally) exclude the vtk parse when importing the mesh.

Background: on large model, the parsing take a considerable amount of time. If no plotting of the model is desired, the parsing is unnecessary.
