### PR TITLE
PyVista deprecation warning

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (pymapdl-reader)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/pymapdl-reader.iml" filepath="$PROJECT_DIR$/.idea/pymapdl-reader.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/pymapdl-reader.iml
+++ b/.idea/pymapdl-reader.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/examples/try_example.py
+++ b/examples/try_example.py
@@ -1,8 +1,0 @@
-import pyvista
-import numpy as np
-
-from ansys.mapdl import reader as pymapdl_reader
-from ansys.mapdl.reader import examples
-
-# Download an example shaft modal analysis result file
-shaft = examples.download_shaft_modal()

--- a/examples/try_example.py
+++ b/examples/try_example.py
@@ -1,0 +1,8 @@
+import pyvista
+import numpy as np
+
+from ansys.mapdl import reader as pymapdl_reader
+from ansys.mapdl.reader import examples
+
+# Download an example shaft modal analysis result file
+shaft = examples.download_shaft_modal()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.14.0
-pyvista>=0.27.2
+numpy>=1.16.0
+pyvista>=0.32.0
 appdirs>=1.4.0
-tqdm>=4.45.0
 matplotlib>=3.0.0
+tqdm>=4.45.0


### PR DESCRIPTION
Fix warnings after plotting of the areas, elements, nodes, etc.:

...\pymapdl\venv\lib\site-packages\pyvista\core\dataset.py:1192: PyvistaDeprecationWarning: Use of point_arrays is deprecated. Use point_data instead.
warnings.warn(

...\pymapdl\venv\lib\site-packages\pyvista\core\dataset.py:1332: PyvistaDeprecationWarning: Use of cell_arrays is deprecated. Use cell_data instead.
warnings.warn(