### PR TITLE
fix pymapdl version

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 vtk<9.1.0
 pyvista>=0.24.0
+ansys-mapdl-core==0.60.4

--- a/tests/test_binary_reader.py
+++ b/tests/test_binary_reader.py
@@ -478,4 +478,4 @@ def test_nodal_time_history(mapdl, transient_thermal):
     assert np.allclose(nnum, mapdl.mesh.nnum)
     for i in range(mapdl.post_processing.nsets):
         mapdl.set(1, i + 1)
-        assert np.allclose(data[i].ravel(), mapdl.post_processing.nodal_temperature)
+        assert np.allclose(data[i].ravel(), mapdl.post_processing.nodal_temperature())


### PR DESCRIPTION
API for `ansys-mapdl-core==0.60.4` changes the `post_processing` attribute and this causes local testing to fail.
