### PR TITLE
Incorporated pathlib.Path compatibility

### DIFF
--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -3,6 +3,8 @@ import io
 import os
 import logging
 from functools import wraps
+import pathlib
+from typing import Union
 
 import numpy as np
 from pyvista._vtk import (VTK_TETRA, VTK_QUADRATIC_TETRA, VTK_PYRAMID,
@@ -37,7 +39,7 @@ class Archive(Mesh):
 
     Parameters
     ----------
-    filename : string
+    filename : string, pathlib.Path
         Filename of block formatted cdb file
 
     read_parameters : bool, optional
@@ -113,9 +115,9 @@ class Archive(Mesh):
                  verbose=False, name=''):
         """Initializes an instance of the archive class."""
         self._read_parameters = read_parameters
-        self._filename = filename
+        self._filename = pathlib.Path(filename)
         self._name = name
-        self._raw = _reader.read(filename, read_parameters=read_parameters,
+        self._raw = _reader.read(self.filename, read_parameters=read_parameters,
                                  debug=verbose)
         super().__init__(self._raw['nnum'],
                          self._raw['nodes'],
@@ -135,6 +137,20 @@ class Archive(Mesh):
         if parse_vtk:
             self._grid = self._parse_vtk(allowable_types,
                                          force_linear, null_unallowed)
+
+    @property
+    def filename(self) -> str:
+        """String form of the filename. Accepts ``pathlib.Path`` and string objects when set."""
+        return str(self._filename)
+
+    @property
+    def pathlib_filename(self) -> pathlib.Path:
+        """Return the ``pathlib.Path`` version of the filename. This property can not be set."""
+        return self._filename
+
+    @filename.setter
+    def filename(self, value: Union[str, pathlib.Path]):
+        self._filename = pathlib.Path(value)
 
     @property
     def raw(self):  # pragma: no cover
@@ -262,7 +278,7 @@ def save_as_archive(filename, grid, mtype_start=1, etype_start=1,
 
     Parameters
     ----------
-    filename : str
+    filename : str, pathlib.Path
        Filename to write archive file.
 
     grid : vtk.UnstructuredGrid

--- a/ansys/mapdl/reader/common.py
+++ b/ansys/mapdl/reader/common.py
@@ -1,6 +1,7 @@
 """Methods common to binary files"""
 import struct
-import os
+import pathlib
+from typing import Union
 from collections import Counter
 
 import numpy as np
@@ -22,7 +23,6 @@ ANSYS_BINARY_FILE_TYPES = {2: 'Element Matrix File',
                            12: 'Result File',
                            16: 'Database File',
                            45: 'Component Mode Synthesis Matrices (CMS) File'}
-
 
 
 # c *** standard usage of the block number (buffers) and file unit number(FUN)
@@ -61,9 +61,9 @@ ANSYS_BINARY_FILE_TYPES = {2: 'Element Matrix File',
 # c     ASI  ->    ASIRSTNM     FUN66        9      asi results
 
 
-class AnsysBinary():
+class AnsysBinary:
     """ANSYS binary file class"""
-    filename = None
+    filename: Union[str, pathlib.Path] = None
 
     # read only file handle
     _cfile = None
@@ -120,7 +120,7 @@ def read_binary(filename, **kwargs):
 
     Parameters
     ----------
-    filename : str
+    filename : str, pathlib.Path
         Filename to read.
 
     **kwargs : keyword arguments
@@ -148,9 +148,9 @@ def read_binary(filename, **kwargs):
     - Jobname.RMG A magnetic analysis
     - Jobname.RFL A FLOTRAN analysis (a legacy results file)
     """
-    if not os.path.isfile(filename):
-        raise FileNotFoundError('%s is not a file or cannot be found' %
-                                str(filename))
+    filename = pathlib.Path(filename)
+    if not filename.is_file():
+        raise FileNotFoundError(f'{filename} is not a file or cannot be found')
 
     file_format = read_standard_header(filename)['file format']
 

--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -1645,6 +1645,7 @@ class CyclicResult(Result):
             plotter.camera_position = cpos
 
         if movie_filename:
+            movie_filename = str(movie_filename)
             if movie_filename.strip()[-3:] == 'gif':
                 plotter.open_gif(movie_filename)
             else:

--- a/ansys/mapdl/reader/dis_result.py
+++ b/ansys/mapdl/reader/dis_result.py
@@ -3,6 +3,8 @@ from inspect import currentframe
 import glob
 import os
 from functools import wraps
+from typing import Union
+import pathlib
 
 import pyvista as pv
 import numpy as np
@@ -17,7 +19,7 @@ from ansys.mapdl.reader._binary_reader import (read_nodal_values_dist,
 from ansys.mapdl.reader._rst_keys import element_index_table_info
 
 
-def find_dis_files(main_file):
+def find_dis_files(main_file: Union[str, pathlib.Path]):
     """Find the individual distributed result files given a main result file"""
     basename = os.path.basename(main_file)
     jobname = basename[:basename.rfind('0')]

--- a/ansys/mapdl/reader/mesh.py
+++ b/ansys/mapdl/reader/mesh.py
@@ -558,7 +558,7 @@ class Mesh():
 
         Parameters
         ----------
-        filename : str
+        filename : str, pathlib.Path
             Filename of output file. Writer type is inferred from
             the extension of the filename.
 
@@ -593,7 +593,7 @@ class Mesh():
         grid = self._parse_vtk(allowable_types=allowable_types,
                                force_linear=force_linear,
                                null_unallowed=null_unallowed)
-        return grid.save(filename, binary=binary)
+        return grid.save(str(filename), binary=binary)
 
     @property
     def n_node(self):

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -100,7 +100,7 @@ class Result(AnsysBinary):
     def __init__(self, filename, read_mesh=True, parse_vtk=True, **kwargs):
         """Load basic result information from result file and init the rst object."""
         self._filename = pathlib.Path(filename)
-        self._cfile = AnsysFile(filename)
+        self._cfile = AnsysFile(str(filename))
         self._resultheader = self._read_result_header()
         self._animating = False
         self.__element_map = None
@@ -4732,7 +4732,7 @@ class Result(AnsysBinary):
     @property
     def _is_thermal(self):
         """True when result file is a rth file"""
-        return self.pathlib_filename.suffix == 'rth'
+        return self.pathlib_filename.suffix == '.rth'
 
     @property
     def _is_cyclic(self):

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import pytest
 import numpy as np
@@ -19,6 +20,7 @@ LINEAR_CELL_TYPES = [VTK_TETRA,
 
 TEST_PATH = os.path.dirname(os.path.abspath(__file__))
 TESTFILES_PATH = os.path.join(TEST_PATH, 'test_data')
+TESTFILES_PATH_PATHLIB = pathlib.Path(TESTFILES_PATH)
 DAT_FILE = os.path.join(TESTFILES_PATH, 'Panel_Transient.dat')
 
 
@@ -47,6 +49,12 @@ def proto_cmblock(array):
         items[c] = -array[i + 1]; c += 1
 
     return items[:c]
+
+
+@pytest.fixture()
+def pathlib_archive():
+    filename = TESTFILES_PATH_PATHLIB / 'ErnoRadiation.cdb'
+    return pymapdl_reader.Archive(filename)
 
 
 @pytest.fixture()
@@ -440,3 +448,23 @@ def test_rlblock_prior_to_nblock():
     archive = pymapdl_reader.Archive(filename)
     assert archive.n_node == 65
     assert archive.n_elem == 36
+
+
+class TestPathlibFilename:
+    def test_pathlib_filename_property(self, pathlib_archive):
+        assert isinstance(pathlib_archive.pathlib_filename, pathlib.Path)
+
+    def test_filename_property_is_string(self, pathlib_archive):
+        filename = TESTFILES_PATH_PATHLIB / 'ErnoRadiation.cdb'
+        a = pymapdl_reader.Archive(filename)
+        assert isinstance(a.filename, str)
+
+    def test_filename_setter_pathlib(self, pathlib_archive):
+        pathlib_archive.filename = pathlib.Path('dummy2')
+        assert isinstance(pathlib_archive.filename, str)
+        assert isinstance(pathlib_archive.pathlib_filename, pathlib.Path)
+
+    def test_filename_setter_string(self, pathlib_archive):
+        pathlib_archive.filename = 'dummy2'
+        assert isinstance(pathlib_archive.filename, str)
+        assert isinstance(pathlib_archive.pathlib_filename, pathlib.Path)

--- a/tests/test_binary_reader.py
+++ b/tests/test_binary_reader.py
@@ -435,23 +435,36 @@ def test_reaction_forces():
     assert np.allclose(forces[:, 1], [-600, 250, 500, -900])
 
 
-def test_thermal_result(thermal_rst):
-    assert thermal_rst._is_thermal
-    assert thermal_rst.result_dof(0) == ['TEMP']
-    with pytest.raises(AttributeError):
-        thermal_rst.nodal_displacement()
+class TestThermalResult:
+    def test_nodal_displacement(self, thermal_rst):
+        assert thermal_rst._is_thermal
+        assert thermal_rst.result_dof(0) == ['TEMP']
+        with pytest.raises(AttributeError):
+            thermal_rst.nodal_displacement()
 
-    with pytest.raises(AttributeError):
-        thermal_rst.nodal_velocity(0)
+    def test_nodal_velocity(self, thermal_rst):
+        assert thermal_rst._is_thermal
+        assert thermal_rst.result_dof(0) == ['TEMP']
+        with pytest.raises(AttributeError):
+            thermal_rst.nodal_velocity(0)
 
-    with pytest.raises(AttributeError):
-        thermal_rst.nodal_acceleration(0)
+    def test_nodal_acceleration(self, thermal_rst):
+        assert thermal_rst._is_thermal
+        assert thermal_rst.result_dof(0) == ['TEMP']
+        with pytest.raises(AttributeError):
+            thermal_rst.nodal_acceleration(0)
 
-    with pytest.raises(AttributeError):
-        thermal_rst.plot_nodal_solution(0, 'NORM')
+    def test_nodal_solution(self, thermal_rst):
+        assert thermal_rst._is_thermal
+        assert thermal_rst.result_dof(0) == ['TEMP']
+        with pytest.raises(AttributeError):
+            thermal_rst.plot_nodal_solution(0, 'NORM')
 
-    with pytest.raises(ValueError):
-        thermal_rst.plot_nodal_solution(0, 'ROTX')
+    def test_plot_nodal_solution(self, thermal_rst):
+        assert thermal_rst._is_thermal
+        assert thermal_rst.result_dof(0) == ['TEMP']
+        with pytest.raises(ValueError):
+            thermal_rst.plot_nodal_solution(0, 'ROTX')
 
 
 def test_plot_temperature(thermal_rst):

--- a/tests/test_emat.py
+++ b/tests/test_emat.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import pytest
 import numpy as np
@@ -19,6 +20,12 @@ def emat():
     return emat_bin
 
 
+@pytest.fixture(scope='module')
+def emat_pathlib():
+    emat_bin = EmatFile(pathlib.Path(emat_filename))
+    return emat_bin
+
+
 def test_load_element(emat):
     dof_idx, element_data = emat.read_element(0)
     assert 'stress' in element_data
@@ -36,3 +43,21 @@ def test_eeqv(emat):
 
 def test_neqv(emat):
     assert np.allclose(np.sort(emat.neqv), emat.nnum)
+
+
+class TestPathlibFilename:
+    def test_pathlib_filename_property(self, emat_pathlib):
+        assert isinstance(emat_pathlib.pathlib_filename, pathlib.Path)
+
+    def test_filename_property_is_string(self, emat_pathlib):
+        assert isinstance(emat_pathlib.filename, str)
+
+    def test_filename_setter_pathlib(self, emat_pathlib):
+        emat_pathlib.filename = pathlib.Path('dummy2')
+        assert isinstance(emat_pathlib.filename, str)
+        assert isinstance(emat_pathlib.pathlib_filename, pathlib.Path)
+
+    def test_filename_setter_string(self, emat_pathlib):
+        emat_pathlib.filename = 'dummy2'
+        assert isinstance(emat_pathlib.filename, str)
+        assert isinstance(emat_pathlib.pathlib_filename, pathlib.Path)

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -2,13 +2,21 @@ import os
 
 import scipy
 import pytest
+import pathlib
 import numpy as np
 
 from ansys.mapdl import reader as pymapdl_reader
 from ansys.mapdl.reader import examples
+from ansys.mapdl.reader.full import FullFile
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 testfiles_path = os.path.join(test_path, 'testfiles')
+
+
+@pytest.fixture()
+def sparse_full_pathlib_full_file():
+    filename = os.path.join(testfiles_path, 'sparse.full')
+    return FullFile(pathlib.Path(filename))
 
 
 @pytest.fixture()
@@ -67,3 +75,21 @@ def test_full_load_km(sparse_full):
 
 def test_load_vector(sparse_full):
     assert not sparse_full.load_vector.any()
+
+
+class TestPathlibFilename:
+    def test_pathlib_filename_property(self, sparse_full_pathlib_full_file):
+        assert isinstance(sparse_full_pathlib_full_file.pathlib_filename, pathlib.Path)
+
+    def test_filename_property_is_string(self, sparse_full_pathlib_full_file):
+        assert isinstance(sparse_full_pathlib_full_file.filename, str)
+
+    def test_filename_setter_pathlib(self, sparse_full_pathlib_full_file):
+        sparse_full_pathlib_full_file.filename = pathlib.Path('dummy2')
+        assert isinstance(sparse_full_pathlib_full_file.filename, str)
+        assert isinstance(sparse_full_pathlib_full_file.pathlib_filename, pathlib.Path)
+
+    def test_filename_setter_string(self, sparse_full_pathlib_full_file):
+        sparse_full_pathlib_full_file.filename = 'dummy2'
+        assert isinstance(sparse_full_pathlib_full_file.filename, str)
+        assert isinstance(sparse_full_pathlib_full_file.pathlib_filename, pathlib.Path)

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -32,6 +32,7 @@ mapdl.allsel()
 mapdl.modal_analysis(nmode=1)
 
 """
+import pathlib
 import platform
 import os
 from shutil import copy
@@ -43,6 +44,7 @@ from pyvista.plotting.renderer import CameraPosition
 
 from ansys.mapdl import reader as pymapdl_reader
 from ansys.mapdl.reader import examples
+from ansys.mapdl.reader.rst import Result
 from ansys.mapdl.reader.examples.downloads import _download_and_read
 
 try:
@@ -82,6 +84,12 @@ else:
 
 temperature_rst = os.path.join(testfiles_path, 'temp_v13.rst')
 temperature_known_result = os.path.join(testfiles_path, 'temp_v13.npz')
+
+
+@pytest.fixture(scope='module')
+def pathlib_result():
+    temperature_rst_pathlib = pathlib.Path(temperature_rst)
+    return Result(temperature_rst_pathlib)
 
 
 @pytest.fixture(scope='module')
@@ -308,6 +316,36 @@ def test_read_temperature():
 def test_plot_nodal_temperature():
     temp_rst = pymapdl_reader.read_binary(temperature_rst)
     temp_rst.plot_nodal_temperature(0, off_screen=True)
+
+
+class TestPathlibFilename:
+    @skip_plotting
+    @pytest.mark.skipif(not os.path.isfile(temperature_rst),
+                        reason="Requires example files")
+    def test_pathlib_filename_property(self, pathlib_result):
+        assert isinstance(pathlib_result.pathlib_filename, pathlib.Path)
+
+    @skip_plotting
+    @pytest.mark.skipif(not os.path.isfile(temperature_rst),
+                        reason="Requires example files")
+    def test_filename_property_is_string(self, pathlib_result):
+        assert isinstance(pathlib_result.filename, str)
+
+    @skip_plotting
+    @pytest.mark.skipif(not os.path.isfile(temperature_rst),
+                        reason="Requires example files")
+    def test_filename_setter_pathlib(self, pathlib_result):
+        pathlib_result.filename = pathlib.Path('dummy2')
+        assert isinstance(pathlib_result.filename, str)
+        assert isinstance(pathlib_result.pathlib_filename, pathlib.Path)
+
+    @skip_plotting
+    @pytest.mark.skipif(not os.path.isfile(temperature_rst),
+                        reason="Requires example files")
+    def test_filename_setter_string(self, pathlib_result):
+        pathlib_result.filename = 'dummy2'
+        assert isinstance(pathlib_result.filename, str)
+        assert isinstance(pathlib_result.pathlib_filename, pathlib.Path)
 
 
 def test_rst_node_components(hex_rst):


### PR DESCRIPTION
In this PR I have added input (and explicit output) compatibility
between pymapdl-reader and the pathlib.Path class. All file path-input
arguments should now be accepted as either strings or pathlib.Path
objects. Additionally there is no breaking change regarding the filename
properties. These will continue to return strings. Wherever possible I
have made it so that internally we store paths as pathlib.Path objects
and they are returned as strings through properties. Setters
additionally will accept strings or pathlib.Path objects.

Users can access the pathlib.Path objects via new `pathlib_filename` properties.
I could not think of a better name, but suggestions are welcome.

~~Unfortunately i have not been able to get the test suite working on my
local machine and so have not been able to write tests to go with these
changes. I would appreciate input from others regarding how to get the
tests running and if my changes do break any existing tests. I do not
believe so but I am very limited in how I can check.~~

With the latest commits and #103 I have managed to get my development version 
working and confirmed the changes work as well as adding tests for them.

This PR is ready for review and merging.

(closes https://github.com/pyansys/pymapdl-reader/issues/98)