### PR TITLE
Instruction regarding development on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -262,6 +262,21 @@ natural frequencies and mode shapes.
     5781.975 Hz
     6919.399 Hz
 
+Developing on Windows
+---------------------
+
+This package is designed to be developed on Linux, and if you need to develop on Windows
+you will need to install your own C++ compiler. We recommend:
+
+ 1. Install Visual C++
+        a. See `here <https://wiki.python.org/moin/WindowsCompilers>`_ for a list of which Python versions correspond to which Visual C++ version
+        b. Only Python <= 3.8 appears to be supported at the moment.
+ 2. Install the development version of pymapdl-reader to your Python environment
+        a. Navigate to the project's top level (the same directory as this README)
+        b. run ``pip install -e .``
+
+To get the package up and running.
+
 License and Acknowledgments
 ---------------------------
 The ``ansys-mapdl-reader`` module is licensed under the MIT license.

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -120,6 +120,7 @@ def test_map_flag_section_data():
         assert np.allclose(rst_2020r2.section_data[key],
                            rst_2021r1.section_data[key])
 
+
 def test_overwrite(tmpdir):
     tmp_path = str(tmpdir.mkdir("tmpdir"))
     rst = pymapdl_reader.read_binary(copy(examples.rstfile, tmp_path))


### PR DESCRIPTION
Added instruction on how to develop the package on Windows as opposed to
Linux, with notes that I would have needed when I tried to do it.

This should help users in the long run because whilst the package is
set to be depreciated in the future development is still required
because of how closely it is tied to pymapdl.

Should the bit I've added be reworded and also maybe moved to the `CONTRIBUTING.md` file? I would appreciate a quick proofread! I think it would be worthwhile to include a message like this somewhere but I'm not sure as to the best place it should go.