### PR TITLE
Made smooth_shading=False by default

### DIFF
--- a/ansys/mapdl/reader/plotting.py
+++ b/ansys/mapdl/reader/plotting.py
@@ -20,7 +20,7 @@ def general_plotter(title, meshes, points, labels,
                     interpolate_before_map=True, cmap=None,
                     render_points_as_spheres=False, render_lines_as_tubes=False,
                     stitle=None,
-                    smooth_shading=None,
+                    smooth_shading=False,
                     # labels kwargs
                     font_size=None,
                     font_family=None,


### PR DESCRIPTION
Fixes #57. Made smooth_shading=False by default. This is the most we can
do in pymapdl-reader without changing pyvista.