### PR TITLE
Removed setters & fixed tests

### DIFF
--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -140,17 +140,13 @@ class Archive(Mesh):
 
     @property
     def filename(self) -> str:
-        """String form of the filename. Accepts ``pathlib.Path`` and string objects when set."""
+        """String form of the filename. This property is read-only."""
         return str(self._filename)
 
     @property
     def pathlib_filename(self) -> pathlib.Path:
         """Return the ``pathlib.Path`` version of the filename. This property can not be set."""
         return self._filename
-
-    @filename.setter
-    def filename(self, value: Union[str, pathlib.Path]):
-        self._filename = pathlib.Path(value)
 
     @property
     def raw(self):  # pragma: no cover

--- a/ansys/mapdl/reader/emat.py
+++ b/ansys/mapdl/reader/emat.py
@@ -357,17 +357,13 @@ class EmatFile(object):
 
     @property
     def filename(self):
-        """String form of the filename. Accepts ``pathlib.Path`` and string objects when set."""
+        """String form of the filename. This property is read-only."""
         return str(self._filename)
 
     @property
     def pathlib_filename(self):
         """Return the ``pathlib.Path`` version of the filename. This property can not be set."""
         return self._filename
-
-    @filename.setter
-    def filename(self, value):
-        self._filename = pathlib.Path(value)
 
     def read_header(self):
         """Read standard emat file header"""

--- a/ansys/mapdl/reader/full.py
+++ b/ansys/mapdl/reader/full.py
@@ -102,17 +102,13 @@ class FullFile(AnsysBinary):
 
     @property
     def filename(self):
-        """String form of the filename. Accepts ``pathlib.Path`` and string objects when set."""
+        """String form of the filename. This property is read-only."""
         return str(self._filename)
 
     @property
     def pathlib_filename(self):
         """Return the ``pathlib.Path`` version of the filename. This property can not be set."""
         return self._filename
-
-    @filename.setter
-    def filename(self, value):
-        self._filename = pathlib.Path(value)
 
     @property
     def k(self):

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -135,17 +135,13 @@ class Result(AnsysBinary):
 
     @property
     def filename(self) -> str:
-        """String form of the filename. Accepts ``pathlib.Path`` and string objects when set."""
+        """String form of the filename. This property is read-only."""
         return str(self._filename)
 
     @property
     def pathlib_filename(self) -> pathlib.Path:
         """Return the ``pathlib.Path`` version of the filename. This property can not be set."""
         return self._filename
-
-    @filename.setter
-    def filename(self, value: Union[str, pathlib.Path]):
-        self._filename = pathlib.Path(value)
 
     @property
     def mesh(self):

--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -460,11 +460,9 @@ class TestPathlibFilename:
         assert isinstance(a.filename, str)
 
     def test_filename_setter_pathlib(self, pathlib_archive):
-        pathlib_archive.filename = pathlib.Path('dummy2')
-        assert isinstance(pathlib_archive.filename, str)
-        assert isinstance(pathlib_archive.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            pathlib_archive.filename = pathlib.Path('dummy2')
 
     def test_filename_setter_string(self, pathlib_archive):
-        pathlib_archive.filename = 'dummy2'
-        assert isinstance(pathlib_archive.filename, str)
-        assert isinstance(pathlib_archive.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            pathlib_archive.filename = 'dummy2'

--- a/tests/test_emat.py
+++ b/tests/test_emat.py
@@ -53,11 +53,10 @@ class TestPathlibFilename:
         assert isinstance(emat_pathlib.filename, str)
 
     def test_filename_setter_pathlib(self, emat_pathlib):
-        emat_pathlib.filename = pathlib.Path('dummy2')
-        assert isinstance(emat_pathlib.filename, str)
-        assert isinstance(emat_pathlib.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            emat_pathlib.filename = pathlib.Path('dummy2')
 
     def test_filename_setter_string(self, emat_pathlib):
-        emat_pathlib.filename = 'dummy2'
-        assert isinstance(emat_pathlib.filename, str)
-        assert isinstance(emat_pathlib.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            emat_pathlib.filename = 'dummy2'
+

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -85,11 +85,9 @@ class TestPathlibFilename:
         assert isinstance(sparse_full_pathlib_full_file.filename, str)
 
     def test_filename_setter_pathlib(self, sparse_full_pathlib_full_file):
-        sparse_full_pathlib_full_file.filename = pathlib.Path('dummy2')
-        assert isinstance(sparse_full_pathlib_full_file.filename, str)
-        assert isinstance(sparse_full_pathlib_full_file.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            sparse_full_pathlib_full_file.filename = pathlib.Path('dummy2')
 
     def test_filename_setter_string(self, sparse_full_pathlib_full_file):
-        sparse_full_pathlib_full_file.filename = 'dummy2'
-        assert isinstance(sparse_full_pathlib_full_file.filename, str)
-        assert isinstance(sparse_full_pathlib_full_file.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            sparse_full_pathlib_full_file.filename = 'dummy2'

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -336,17 +336,15 @@ class TestPathlibFilename:
     @pytest.mark.skipif(not os.path.isfile(temperature_rst),
                         reason="Requires example files")
     def test_filename_setter_pathlib(self, pathlib_result):
-        pathlib_result.filename = pathlib.Path('dummy2')
-        assert isinstance(pathlib_result.filename, str)
-        assert isinstance(pathlib_result.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            pathlib_result.filename = pathlib.Path('dummy2')
 
     @skip_plotting
     @pytest.mark.skipif(not os.path.isfile(temperature_rst),
                         reason="Requires example files")
     def test_filename_setter_string(self, pathlib_result):
-        pathlib_result.filename = 'dummy2'
-        assert isinstance(pathlib_result.filename, str)
-        assert isinstance(pathlib_result.pathlib_filename, pathlib.Path)
+        with pytest.raises(AttributeError):
+            pathlib_result.filename = 'dummy2'
 
 
 def test_rst_node_components(hex_rst):


### PR DESCRIPTION
This fixes #104. Removed the newly introduced filename setters and
amended docstrings to indicate the properties are read-only.
Additionally amended the tests to check the properties ARE read only
instead of checking that they were write as well.