### PR TITLE
Removing python 3.6

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -1,4 +1,4 @@
-name: GH Actions
+name: Actions
 
 # repo specific gh actions
 env:
@@ -29,6 +29,7 @@ jobs:
         run: |
           pip install -r requirements_style.txt --disable-pip-version-check
           make
+
   doc_build:
     name: Build Documentation
     runs-on: ubuntu-latest
@@ -47,6 +48,7 @@ jobs:
           sudo apt-get install libgl1-mesa-glx xvfb
           pip install pyvista
           xvfb-run python -c "import pyvista; print(pyvista.Report())"
+
       - name: Install ansys-mapdl-reader
         run: |
           pip install -r requirements_build.txt --disable-pip-version-check
@@ -54,6 +56,7 @@ jobs:
           pip install dist/ansys*.whl --disable-pip-version-check
           cd tests/
           xvfb-run python -c "from ansys.mapdl import reader as pymapdl_reader; print(pymapdl_reader.Report())"
+
       - name: Build Documentation
         run: |
           sudo apt install pandoc -qy
@@ -62,6 +65,7 @@ jobs:
           sudo apt install zip
           cd doc/build/html/
           zip ../../../${{ env.PACKAGE_NAME }}-HTML.zip ./*
+
       - name: Upload
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ setup(
                            language='c++'),
                  ],
 
-    python_requires='>=3.6.*',
+    python_requires='>=3.7.*',
     keywords='vtk MAPDL ANSYS cdb full rst',
     package_data={'ansys.mapdl.reader.examples': ['TetBeam.cdb',
                                                   'HexBeam.cdb',


### PR DESCRIPTION
Python 3.6 came to the 'end-of-life' (EOL) stage, hence it should not be used in the CICD. In fact, it cannot be.