### PR TITLE
Fix/removing python3.10 wheels

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -131,6 +131,10 @@ jobs:
                --rm -v `pwd`:/io \
                quay.io/pypa/manylinux2014_x86_64 \
                /io/.ci/build_wheels.sh ${{ matrix.python-version }}
+
+      - name: Install VTK on Python 3.10
+        if: matrix.python-version == '3.10'
+        run: pip install --find-links https://wheels.pyvista.org/ vtk
 
       - name: Build wheel on Windows
         if: ${{ runner.os == 'Windows' }}

--- a/README.rst
+++ b/README.rst
@@ -43,14 +43,32 @@ Installation
 ------------
 Installation through pip::
 
-    pip install ansys-mapdl-reader
+   pip install ansys-mapdl-reader
 
 You can also visit `pymapdl-reader <https://github.com/pyansys/pymapdl-reader>`_
 to download the source or releases from GitHub.
 
+Python 3.10 Extra Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Loading and Plotting an ANSYS Archive File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PyMAPDL-Reader requires the `VTK library <https://vtk.org/>`_ which, at the
+moment, is not available for Python 3.10 in `their official channel
+<https://pypi.org/project/vtk/>`_.
+
+If you wish to install PyMAPDL-Reader in Python 3.10, you can still do it by
+using the unofficial VTK wheel from PyVista using ``--find-links``. This tells ``pip`` to look for vtk at `wheels.pyvista.org <https://wheels.pyvista.org/>`_. Use this with::
+
+    pip install ansys-mapdl-reader --find-links https://wheels.pyvista.org/
+
+Please visit `Unofficial VTK Wheels for Python 3.10
+<https://github.com/pyvista/pyvista/discussions/2064>`_ for further details.
+
+
+Examples
+--------
+
+Loading and Plotting a MAPDL Archive File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ANSYS archive files containing solid elements (both legacy and
 modern), can be loaded using Archive and then converted to a vtk
 object.
@@ -215,7 +233,7 @@ movie_filename and animate it with:
 
 
 Reading a Full File
--------------------
+~~~~~~~~~~~~~~~~~~~
 This example reads in the mass and stiffness matrices associated with
 the above example.
 
@@ -276,15 +294,6 @@ you will need to install your own C++ compiler. We recommend:
         b. run ``pip install -e .``
 
 To get the package up and running.
-
-PyMAPDL-Reader and Python 3.10
-------------------------------
-PyMAPDL-Reader requires the `VTK library <https://vtk.org/>`_ which, at the moment, is not available for Python 3.10 in `their official channel <https://pypi.org/project/vtk/>`_.
-
-If you wish to install PyMAPDL-Reader in a Python 3.10 virtual environment, you can still do it by installing first an unofficial VTK library build.
-We do recommend to follow `this discussion <https://github.com/pyvista/pyvista/discussions/2064>`_ for further details.
-
-After you installed VTK, you can proceed to install PyMAPDL-Reader using `pip`.
 
 
 License and Acknowledgments

--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,16 @@ you will need to install your own C++ compiler. We recommend:
 
 To get the package up and running.
 
+PyMAPDL-Reader and Python 3.10
+------------------------------
+PyMAPDL-Reader requires the `VTK library <https://vtk.org/>`_ which, at the moment, is not available for Python 3.10 in `their official channel <https://pypi.org/project/vtk/>`_.
+
+If you wish to install PyMAPDL-Reader in a Python 3.10 virtual environment, you can still do it by installing first an unofficial VTK library build.
+We do recommend to follow `this discussion <https://github.com/pyvista/pyvista/discussions/2064>`_ for further details.
+
+After you installed VTK, you can proceed to install PyMAPDL-Reader using `pip`.
+
+
 License and Acknowledgments
 ---------------------------
 The ``ansys-mapdl-reader`` module is licensed under the MIT license.

--- a/setup.py
+++ b/setup.py
@@ -109,19 +109,6 @@ if not is64:
                            'Please check the version of Python installed at\n'
                            '%s' % sys.executable)
 
-
-if sys.version_info.minor == 10 and is64:
-    # use pip to check if vtk is available or installed
-    sys_name = platform.system()
-    if sys_name == 'Linux':
-        install_requires.append(
-            'vtk @ https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
-        )
-    elif sys_name == 'Windows':
-        install_requires.append(
-            'vtk @ https://github.com/pyvista/pyvista-wheels/raw/main/vtk-9.1.0.dev0-cp310-cp310-win_amd64.whl',
-        )
-
 setup(
     name='ansys-mapdl-reader',
     packages=['ansys.mapdl.reader', 'ansys.mapdl.reader.examples'],


### PR DESCRIPTION
Close #115 by removing support to python 3.10

It should be noticed the support is dropped because of lack of official wheels to install VTK in Python 3.10. Until then, python 3.10 is discouraged, but still possible to use if needed (See readme section `PyMAPDL-Reader and Python 3.10`)