### PR TITLE
Adding PyMAPDL unit tests

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -263,12 +263,6 @@ jobs:
         mapdl-version: ['v21.1.1', 'v21.2.1', 'v22.1.0']
 
     steps:
-    
-      - name: Downloading artifacts
-        uses: actions/download-artifact@v2
-
-      - name: Display structure of downloaded artifact files
-        run: ls -R
 
       - name: Checkout PyMAPDL
         uses: actions/checkout@v3
@@ -276,6 +270,12 @@ jobs:
           repository: 'pyansys/pymapdl' #checking out main. Not release
 
       - name: Display structure of downloaded PyMAPDL files
+        run: ls -R
+
+      - name: Downloading artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Display structure of downloaded artifact files
         run: ls -R
 
       - name: Setup Python

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -309,7 +309,7 @@ jobs:
 
       - name: Install ansys-mapdl-reader
         run: |
-          pip install pymapdl-reader/pymapdl-reader/ansys-mapdl-reader-${{ runner.os }}-${{ matrix.python-version }}/*.whl
+          pip install ./ansys-mapdl-reader-${{ runner.os }}-${{ matrix.python-version }}/*.whl
           xvfb-run python -c "from ansys.mapdl import reader as pymapdl_reader; print(pymapdl_reader); print('Installation and smoke test correct')"
 
       - name: Pull, launch, and validate MAPDL service

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -267,12 +267,15 @@ jobs:
       - name: Downloading artifacts
         uses: actions/download-artifact@v2
 
+      - name: Display structure of downloaded artifact files
+        run: ls -R
+
       - name: Checkout PyMAPDL
         uses: actions/checkout@v3
         with:
           repository: 'pyansys/pymapdl' #checking out main. Not release
 
-      - name: Display structure of downloaded files
+      - name: Display structure of downloaded PyMAPDL files
         run: ls -R
 
       - name: Setup Python
@@ -306,7 +309,7 @@ jobs:
 
       - name: Install ansys-mapdl-reader
         run: |
-          pip install ansys-mapdl-reader-${{ runner.os }}-${{ matrix.python-version }}/*.whl
+          pip install pymapdl-reader/pymapdl-reader/ansys-mapdl-reader-${{ runner.os }}-${{ matrix.python-version }}/*.whl
           xvfb-run python -c "from ansys.mapdl import reader as pymapdl_reader; print(pymapdl_reader); print('Installation and smoke test correct')"
 
       - name: Pull, launch, and validate MAPDL service

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -312,12 +312,17 @@ jobs:
           pip install ansys-mapdl-reader-${{ runner.os }}-3.8/*.whl
           xvfb-run python -c "from ansys.mapdl import reader as pymapdl_reader; print(pymapdl_reader); print('Installation and smoke test correct')"
 
+      - name: Login in Github Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull, launch, and validate MAPDL service
         run: .ci/start_mapdl.sh
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          GH_PAT: ${{ secrets.REPO_DOWNLOAD_PAT }}
           MAPDL_IMAGE: ${{ env.DOCKER_PACKAGE }}:${{ matrix.mapdl-version }}
 
       - name: Unit Testing

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -309,7 +309,7 @@ jobs:
 
       - name: Install ansys-mapdl-reader
         run: |
-          pip install ./ansys-mapdl-reader-${{ runner.os }}-3.8/*.whl
+          pip install ansys-mapdl-reader-${{ runner.os }}-3.8/*.whl
           xvfb-run python -c "from ansys.mapdl import reader as pymapdl_reader; print(pymapdl_reader); print('Installation and smoke test correct')"
 
       - name: Pull, launch, and validate MAPDL service

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -5,6 +5,10 @@ env:
   SHELLOPTS: 'errexit:pipefail'
   PACKAGE_NAME: ansys-mapdl-reader
   PYVISTA_OFF_SCREEN: true
+  PYMAPDL_PORT: 21000  # default won't work on GitHub runners
+  PYMAPDL_DB_PORT: 21001  # default won't work on GitHub runners
+  PYMAPDL_START_INSTANCE: FALSE
+  DOCKER_PACKAGE: ghcr.io/pyansys/pymapdl/mapdl
 
 on:
   pull_request:
@@ -249,9 +253,82 @@ jobs:
   #         cd tests
   #         pytest -v
 
+
+  pymapdl_tests:
+    name: PyMAPDL Unit Testing
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        mapdl-version: ['v21.1.1', 'v21.2.1', 'v22.1.0']
+
+    steps:
+    
+      - name: Downloading artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Checkout PyMAPDL
+        uses: actions/checkout@v3
+        with:
+          repository: 'pyansys/pymapdl' #checking out main. Not release
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install OS packages
+        run: |
+          sudo apt update
+          sudo apt install libgl1-mesa-glx xvfb
+
+      - name: Linux pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}
+          restore-keys: |
+            Python-${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Test virtual framebuffer
+        run: |
+          pip install -r .ci/requirements_test_xvfb.txt
+          xvfb-run python .ci/display_test.py
+
+      - name: Install ansys-mapdl-core
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
+
+      - name: Install ansys-mapdl-reader
+        run: |
+          pip install ansys-mapdl-reader-${{ runner.os }}-${{ matrix.python-version }}/*.whl
+          xvfb-run python -c "from ansys.mapdl import reader as pymapdl_reader; print(pymapdl_reader); print('Installation and smoke test correct')"
+
+      - name: Pull, launch, and validate MAPDL service
+        run: .ci/start_mapdl.sh
+        env:
+          LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GH_PAT: ${{ secrets.REPO_DOWNLOAD_PAT }}
+          MAPDL_IMAGE: ${{ env.DOCKER_PACKAGE }}:${{ matrix.mapdl-version }}
+
+      - name: Unit Testing
+        run: |
+          pip install -r requirements/requirements_tests.txt
+          xvfb-run pytest -v
+
+      - name: Display MAPDL Logs
+        if: always()
+        run: cat log.txt
+  
   Release:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [check_style, doc_build, build] # , mac_build
+    needs: [check_style, doc_build, build, pymapdl_tests] # , mac_build
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -292,9 +292,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}
+          key: Python-${{ runner.os }}-3.8-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements_*.txt') }}
           restore-keys: |
-            Python-${{ runner.os }}-${{ matrix.python-version }}
+            Python-${{ runner.os }}-3.8
 
       - name: Test virtual framebuffer
         run: |
@@ -309,7 +309,7 @@ jobs:
 
       - name: Install ansys-mapdl-reader
         run: |
-          pip install ./ansys-mapdl-reader-${{ runner.os }}-${{ matrix.python-version }}/*.whl
+          pip install ./ansys-mapdl-reader-${{ runner.os }}-3.8/*.whl
           xvfb-run python -c "from ansys.mapdl import reader as pymapdl_reader; print(pymapdl_reader); print('Installation and smoke test correct')"
 
       - name: Pull, launch, and validate MAPDL service


### PR DESCRIPTION
Since PyMAPDL and the legacy reader are coupled very tightly (I know we want to undo that), and since last release had to be taken down because an Python SegFault in the downstream PyMAPDL; I believe it is the best interest to have this in place to take actions before publish any release.