### PR TITLE
Revert "Correcting element mapping to plot `TARGE170` elements"

### DIFF
--- a/ansys/mapdl/reader/elements.py
+++ b/ansys/mapdl/reader/elements.py
@@ -401,8 +401,8 @@ _etype_map = [0, 2,  # LINK1
               0,  # UNUSED166
               0,  # UNUSED167
               5,  # SOLID168
-              2,  # TARGE169
-              3,  # TARGE170
+              0,  # TARGE169
+              0,  # TARGE170
               2,  # CONTA171
               2,  # CONTA172
               3,  # CONTA173


### PR DESCRIPTION
Reverts pyansys/pymapdl-reader#125

#125 generates a Python Segmentation Fault when issuing `test_plot_nodal_contact_friction_stress`

```
tests/test_post.py::test_plot_nodal_plastic_eqv_strain[False] PASSED     [ 61%]
tests/test_post.py::test_nodal_contact_friction_stress[False] PASSED     [ 61%]
tests/test_post.py::test_plot_nodal_contact_friction_stress[False] Fatal Python error: Segmentation fault

Thread 0x00007fcf29b61700 (most recent call first):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/threading.py", line 306 in wait
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/threading.py", line 558 in wait
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/tqdm/_monitor.py", line 60 in run
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/threading.py", line 932 in _bootstrap_inner
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/threading.py", line 890 in _bootstrap

Current thread 0x00007fcf43ac8740 (most recent call first):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pyvista/core/filters/__init__.py", line 36 in _update_alg
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pyvista/core/filters/poly_data.py", line 1410 in compute_normals
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pyvista/plotting/_plotting.py", line 97 in prepare_smooth_shading
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pyvista/plotting/plotting.py", line 2178 in add_mesh
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/ansys/mapdl/core/plotting.py", line 250 in general_plotter
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/ansys/mapdl/core/post.py", line 556 in _plot_point_scalars
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/ansys/mapdl/core/post.py", line 3177 in plot_nodal_contact_friction_stress
  File "/home/runner/work/pymapdl-reader/pymapdl-reader/tests/test_post.py", line 1017 in test_plot_nodal_contact_friction_stress
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/python.py", line 192 in pytest_pyfunc_call
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/python.py", line 1[761](https://github.com/pyansys/pymapdl-reader/runs/6126607341?check_suite_focus=true#step:14:761) in runtest
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 166 in pytest_runtest_call
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 259 in <lambda>
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 338 in from_call
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 258 in call_runtest_hook
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 219 in call_and_report
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 130 in runtestprotocol
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/runner.py", line 111 in pytest_runtest_protocol
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 347 in pytest_runtestloop
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 322 in _main
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 268 in wrap_session
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/main.py", line 315 in pytest_cmdline_main
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/config/__init__.py", line 164 in main
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/_pytest/config/__init__.py", line 187 in console_main
  File "/opt/hostedtoolcache/Python/3.8.12/x64/bin/pytest", line 8 in <module>
Segmentation fault (core dumped)
Error: Process completed with exit code 139.
```