### PR TITLE
Adding stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - Future
+  - MAPDL
+# Label to use when marking an issue as stale
+staleLabel:
+  - Stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Closed due to inactivity. Feel free to reopen if there is new information
+  or interest. 
+  Thank you!


### PR DESCRIPTION
Adding a bot which notifies in stale issues, and eventually close them.

This bot has been added to the Pyansys org, but I only give rights to access pymapdl and pymapdl reader.

https://github.com/marketplace/stale 

Same as https://github.com/pyansys/pymapdl/pull/1058