### PR TITLE
add support for missing nodes

### DIFF
--- a/tests/archive/test_archive.py
+++ b/tests/archive/test_archive.py
@@ -160,6 +160,21 @@ def test_missing_midside():
     assert not np.any(archive.grid.celltypes == VTK_TETRA)
 
 
+def test_missing_midside_write(tmpdir):
+    allowable_types = [45, 95, 185, 186, 92, 187]
+    archive_file = os.path.join(TESTFILES_PATH, "mixed_missing_midside.cdb")
+    archive = pymapdl_reader.Archive(archive_file, allowable_types=allowable_types)
+
+    filename = str(tmpdir.join("tmp.cdb"))
+    with pytest.raises(RuntimeError, match="Unsupported element types"):
+        pymapdl_reader.save_as_archive(filename, archive.grid, exclude_missing=True)
+
+    pymapdl_reader.save_as_archive(
+        filename, archive.grid, exclude_missing=True, reset_etype=True
+    )
+    archive_new = pymapdl_reader.Archive(filename)
+
+
 def test_writehex(tmpdir, hex_archive):
     filename = str(tmpdir.mkdir("tmpdir").join("tmp.cdb"))
     pymapdl_reader.save_as_archive(filename, hex_archive.grid)


### PR DESCRIPTION
Add support for missing nodes with the archive reader.

This allows you to write out archive files that have missing midside nodes by enabling ``exclude_missing``.
