### PR TITLE
add additional check to ignore invalid harmonic indices

### DIFF
--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -118,6 +118,12 @@ class CyclicResult(Result):
             self._is_repeated_mode = np.array([False])
             return
 
+        # should not have repeated modes at harmonic index of 0 or N/2
+        self._is_repeated_mode[self._resultheader["hindex"] == 0] = False
+        self._is_repeated_mode[
+            self._resultheader["hindex"] == self.n_sector // 2
+        ] = False
+
         self._repeated_index = np.empty(self._is_repeated_mode.size, np.int)
         self._repeated_index[:] = -1
         if np.any(self._is_repeated_mode):


### PR DESCRIPTION
Add an additional check to stop registering certain harmonic indices simply based on frequency. I'm keeping the old check in-place for legacy reasons, but the only required checks should be 0 and `N // 2`.
