### PR TITLE
Do not test Py3.11 on Mac OS

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -156,7 +156,6 @@ jobs:
           retention-days: 7
 
   mac_build:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     name: Build wheels on MacOS
     runs-on: macos-latest
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -79,7 +79,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           folder: doc/build/html
           clean: true

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -156,6 +156,7 @@ jobs:
           retention-days: 7
 
   mac_build:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     name: Build wheels on MacOS
     runs-on: macos-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ filterwarnings = [
 ]
 
 [tool.cibuildwheel]
-select = "cp3{7,8,9,10}-*"
 archs = ["auto64"]  # 64-bit only
 skip = "pp* *musllinux*"  # disable PyPy and musl-based wheels
 test-requires = "ansys-mapdl-core>=0.60.4 matplotlib pytest scipy"
@@ -29,4 +28,4 @@ test-command = "pytest {project}/tests"
 [tool.cibuildwheel.macos]
 # https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
 archs = ["x86_64", "universal2"]
-test-skip = ["*_arm64", "*_universal2:arm64"]
+test-skip = ["*_arm64", "*_universal2:arm64", "*cp311*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ filterwarnings = [
 ]
 
 [tool.cibuildwheel]
+select = "cp3{7,8,9,10}-*"
 archs = ["auto64"]  # 64-bit only
 skip = "pp* *musllinux*"  # disable PyPy and musl-based wheels
 test-requires = "ansys-mapdl-core>=0.60.4 matplotlib pytest scipy"


### PR DESCRIPTION
Do not test Python 3.11 on MacOS until VTK has a release for 3.11
