### PR TITLE
Fix complex rotor cyclic stress

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
   - id: flake8
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.1.0
+  rev: v2.2.2
   hooks:
   - id: codespell
 

--- a/ansys/mapdl/reader/common.py
+++ b/ansys/mapdl/reader/common.py
@@ -301,7 +301,7 @@ def parse_header(table, keys):
 
 
 def two_ints_to_long(intl, inth):
-    """Interpert two ints as one long"""
+    """Interpret two ints as one long"""
     longint = struct.pack(">I", inth) + struct.pack(">I", intl)
     return struct.unpack(">q", longint)[0]
 

--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -278,8 +278,7 @@ class CyclicResult(Result):
         result_expanded *= cjang.reshape(-1, 1, 1)
         if as_complex:
             return result_expanded
-        else:
-            return np.real(result_expanded)
+        return np.real(result_expanded)
 
     def _expand_cyclic_modal_tensor(
         self, result, result_r, hindex, phase, as_complex, full_rotor, stress=True

--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -1083,7 +1083,7 @@ class CyclicResult(Result):
         equivalent stress.
         """
         if as_complex and full_rotor:
-            raise ValueError("complex and full_rotor cannot both be True")
+            raise ValueError("`complex` and `full_rotor` cannot both be True")
 
         # get component stress
         nnum, stress = self.nodal_stress(rnum, phase, as_complex, full_rotor)
@@ -1093,6 +1093,11 @@ class CyclicResult(Result):
             stress_r = np.imag(stress)
             stress = np.real(stress)
 
+            if not stress.flags["C_CONTIGUOUS"]:
+                stress = np.ascontiguousarray(stress)
+            if not stress_r.flags["C_CONTIGUOUS"]:
+                stress_r = np.ascontiguousarray(stress_r)
+
             pstress, isnan = _binary_reader.compute_principal_stress(stress)
             pstress[isnan] = np.nan
             pstress_r, isnan = _binary_reader.compute_principal_stress(stress_r)
@@ -1100,7 +1105,7 @@ class CyclicResult(Result):
 
             return nnum, pstress + 1j * pstress_r
 
-        elif full_rotor:
+        if full_rotor:
             # compute principle stress for each sector
             pstress = np.empty((self.n_sector, stress.shape[1], 5), np.float64)
             for i in range(stress.shape[0]):
@@ -1108,10 +1113,9 @@ class CyclicResult(Result):
                 pstress[i, isnan] = np.nan
             return nnum, pstress
 
-        else:
-            pstress, isnan = _binary_reader.compute_principal_stress(stress)
-            pstress[isnan] = np.nan
-            return nnum, pstress
+        pstress, isnan = _binary_reader.compute_principal_stress(stress)
+        pstress[isnan] = np.nan
+        return nnum, pstress
 
     def plot_nodal_solution(
         self,

--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -1143,7 +1143,7 @@ class CyclicResult(Result):
 
         comp : str, optional
             Display component to display.  Options are 'x', 'y', 'z',
-            and 'norm', corresponding to the x directin, y direction,
+            and 'norm', corresponding to the x direction, y direction,
             z direction, and the normalized direction:
             ``(x**2 + y**2 + z**2)**0.5``
 

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -1359,7 +1359,7 @@ class Result(AnsysBinary):
         Examples
         --------
         Return the nodal solution (in this case, displacement) for the
-        first result of ``"file.rst"``
+        first result of ``"file.rst"``.
 
         >>> from ansys.mapdl import reader as pymapdl_reader
         >>> rst = pymapdl_reader.read_binary('file.rst')

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -609,7 +609,7 @@ class Result(AnsysBinary):
                 table = self.read_record(ptr_sec + offset)
                 self._section_data[int(table[0])] = table[1:]
 
-        # it might be possible to interpert the section data...
+        # it might be possible to interpret the section data...
         # sec[3] # total thickness
         # sec[4] # number of layers (?)
         # sec[5] # total integration points (?)
@@ -1358,7 +1358,7 @@ class Result(AnsysBinary):
 
         Examples
         --------
-        Return the nodal soltuion (in this case, displacement) for the
+        Return the nodal solution (in this case, displacement) for the
         first result of ``"file.rst"``
 
         >>> from ansys.mapdl import reader as pymapdl_reader

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -120,7 +120,7 @@ sphinx_gallery_conf = {
     ],
     # path where to save gallery generated examples
     "gallery_dirs": ["examples"],
-    # Patter to search for example files
+    # Pattern to search for example files
     "filename_pattern": r"\.py",
     # Remove the "Download all examples" button from the top level gallery
     # "download_all_examples": False,

--- a/doc/source/user_guide/loading_results.rst
+++ b/doc/source/user_guide/loading_results.rst
@@ -559,7 +559,7 @@ will return which modes are available:
     Available modes: [0 1 2 3 4 5 6 7 8 9]
 
 Results from a cyclic analysis require additional post processing to
-be interperted correctly.  Mode shapes are stored within the result
+be interpreted correctly.  Mode shapes are stored within the result
 file as unprocessed parts of the real and imaginary parts of a modal
 solution.  ``ansys-mapdl-reader`` combines these values into a single
 complex array and then returns the real result of that array.

--- a/tests/test_cyclic.py
+++ b/tests/test_cyclic.py
@@ -106,10 +106,25 @@ def test_nodal_cyclic_modal(academic_rotor, load_step, sub_step, rtype):
     # np.abs(pdiff).max()
     # this number is small (aprox 0.0002%)
 
+    # verify we can get complex results
+    nnum, stress = academic_rotor.principal_nodal_stress(
+        rnum,
+        as_complex=False,
+    )
+    nnum_com, stress_com = academic_rotor.principal_nodal_stress(
+        rnum,
+        as_complex=True,
+    )
+    assert np.allclose(np.real(stress_com), stress)
+    assert np.allclose(nnum, nnum_com)
+
+    with pytest.raises(ValueError, match="cannot both be True"):
+        academic_rotor.principal_nodal_stress(rnum, as_complex=True, full_rotor=True)
+
 
 def test_non_cyclic():
     with pytest.raises(TypeError):
-        rst = CyclicResult(examples.rstfile)
+        CyclicResult(examples.rstfile)
 
 
 @skip_windows


### PR DESCRIPTION
``numpy`` no returns a non-contiguous array when converting with ``np.real`` when the datatype is ``np.complex128``.
