### PR TITLE
limit cibuildwheel up-to 3.10

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -160,7 +160,6 @@ jobs:
           retention-days: 7
 
   mac_build:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     name: Build wheels on MacOS
     runs-on: macos-latest
 
@@ -169,6 +168,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.3
+        with:
+            python-version: 3.7 - 3.10
 
       - name: List generated wheels
         run: |

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
             language="c++",
         ),
     ],
-    python_requires=">=3.7.*",
+    python_requires=">=3.7",
     keywords="vtk MAPDL ANSYS cdb full rst",
     package_data={
         "ansys.mapdl.reader.examples": [


### PR DESCRIPTION
MacOS build is failing for ``pymapdl-reader``. This should resolve it.
