### PR TITLE
Replazing old numpy data types (``numpy.<datatype>``) with new ones (``numpy.<datatype>_``)

### DIFF
--- a/ansys/mapdl/reader/archive.py
+++ b/ansys/mapdl/reader/archive.py
@@ -646,15 +646,15 @@ def save_as_archive(
             # write node components
             for node_key in grid.point_data:
                 arr = grid.point_data[node_key]
-                if arr.dtype in [np.uint8, np.bool]:
-                    items = nodenum[arr.view(np.bool)]
+                if arr.dtype in [np.uint8, np.bool_]:
+                    items = nodenum[arr.view(np.bool_)]
                     write_cmblock(fid, items, node_key, "NODE")
 
             # write element components
             for node_key in grid.cell_data:
                 arr = grid.cell_data[node_key]
-                if arr.dtype in [np.uint8, np.bool]:
-                    items = enum[arr.view(np.bool)]
+                if arr.dtype in [np.uint8, np.bool_]:
+                    items = enum[arr.view(np.bool_)]
                     write_cmblock(fid, items, node_key, "ELEMENT")
 
 

--- a/ansys/mapdl/reader/cyclic_reader.py
+++ b/ansys/mapdl/reader/cyclic_reader.py
@@ -124,7 +124,7 @@ class CyclicResult(Result):
             self._is_repeated_mode = np.array([False])
             return
 
-        self._repeated_index = np.empty(self._is_repeated_mode.size, np.int)
+        self._repeated_index = np.empty(self._is_repeated_mode.size, np.int_)
         self._repeated_index[:] = -1
         if np.any(self._is_repeated_mode):
             self._repeated_index[mask_a] = np.nonzero(mask_b)[0]

--- a/ansys/mapdl/reader/cython/_binary_reader.pyx
+++ b/ansys/mapdl/reader/cython/_binary_reader.pyx
@@ -1403,7 +1403,7 @@ def tensor_arbitrary(double [:, ::1] stress, double [:, :] trans):
         stress[i, 4] = r5
         stress[i, 5] = r6
 
-    return np.asarray(isnan, np.bool)
+    return np.asarray(isnan, np.bool_)
 
 
 def tensor_strain_arbitrary(double [:, ::1] stress, double [:, :] trans):
@@ -1476,7 +1476,7 @@ def tensor_strain_arbitrary(double [:, ::1] stress, double [:, :] trans):
         stress[i, 4] = r5*2
         stress[i, 5] = r6*2
 
-    return np.asarray(isnan, np.bool)
+    return np.asarray(isnan, np.bool_)
 
 
 def tensor_rotate_z(double [:, :] stress, float theta_z):
@@ -1518,7 +1518,7 @@ def tensor_rotate_z(double [:, :] stress, float theta_z):
         stress[i, 4] = c*s_yz + s*s_xz
         stress[i, 5] = c*s_xz - s*s_yz
 
-    return np.asarray(isnan, dtype=np.bool)
+    return np.asarray(isnan, dtype=np.bool_)
 
 
 def compute_principal_stress(double [:, ::1] stress):
@@ -1615,7 +1615,7 @@ def compute_principal_stress(double [:, ::1] stress):
 
         pstress[i, 4] = sqrt(0.5*(c1**2 + c2**2 + c3**2))
 
-    return np.asarray(pstress), np.asarray(isnan, np.bool)
+    return np.asarray(pstress), np.asarray(isnan, np.bool_)
 
 
 def affline_transform(float_or_double [:, ::1] points, float_or_double [:, ::1] t):
@@ -1669,7 +1669,7 @@ def cells_with_all_nodes(index_type [::1] offset, index_type [::1] cells,
                 if point_mask[cells[j]] != 1:
                     cell_mask[i] = 0
 
-    return np.asarray(cell_mask, dtype=np.bool)
+    return np.asarray(cell_mask, dtype=np.bool_)
 
 
 def cells_with_any_nodes(index_type [::1] offset, index_type [::1] cells,
@@ -1693,7 +1693,7 @@ def cells_with_any_nodes(index_type [::1] offset, index_type [::1] cells,
                     cell_mask[i] = 1
                     break
 
-    return np.asarray(cell_mask, dtype=np.bool)
+    return np.asarray(cell_mask, dtype=np.bool_)
 
 
 def midside_mask(uint8 [::1] celltypes, index_type [::1] cells,
@@ -1746,7 +1746,7 @@ def midside_mask(uint8 [::1] celltypes, index_type [::1] cells,
                 mask[cells[j]] = 1
 
     # return as a bool array without copying
-    return np.asarray(mask).view(np.bool)
+    return np.asarray(mask).view(np.bool_)
 
 
 def euler_cart_to_cyl(double [:, ::1] stress, double [::1] angles):

--- a/ansys/mapdl/reader/cython/_cellqual.pyx
+++ b/ansys/mapdl/reader/cython/_cellqual.pyx
@@ -1057,7 +1057,7 @@ cdef inline double tet_quad_qual(int64_t [::1] cells, int c,
         print '# Node {:d}'.format(j)
         print 'for j in range(3):'
         endtxt = ''
-        k = pre_j[4*j].astype(np.int)
+        k = pre_j[4*j].astype(np.int_)
         for i in np.nonzero(k)[0].tolist():
             if k[i] == -1:
                 endtxt += ' + pts[ind{:d}, j]'.format(i)
@@ -1071,7 +1071,7 @@ cdef inline double tet_quad_qual(int64_t [::1] cells, int c,
         
         for m in range(1, 4):
             txt = 'e{:d}[j] ='.format(m - 1)
-            k = pre_j[4*j + m].astype(np.int)
+            k = pre_j[4*j + m].astype(np.int_)
             for i in np.nonzero(k)[0].tolist():
                 if k[i] == 1:
                     txt += ' + pts[ind{:d}, j]'.format(i)
@@ -2894,7 +2894,7 @@ cdef inline double hex_quad_qual(int64_t [::1] cells, int c,
                     [0, 4],# 16
                     [1, 5],# 17
                     [2, 6],# 18
-                    [3, 7]], np.int)# 19
+                    [3, 7]], np.int_)# 19
     
     midpt = (edgept[idx[:, 0]] + edgept[idx[:, 1]])/2
     

--- a/ansys/mapdl/reader/full.py
+++ b/ansys/mapdl/reader/full.py
@@ -296,10 +296,10 @@ class FullFile(AnsysBinary):
             Sort these values by node number and DOF by enabling the
             sort parameter.
 
-        k : (n x n) np.float or scipy.csc array
+        k : (n x n) np.float_ or scipy.csc array
             Stiffness array
 
-        m : (n x n) np.float or scipy.csc array
+        m : (n x n) np.float_ or scipy.csc array
             Mass array
 
         Examples

--- a/ansys/mapdl/reader/rst.py
+++ b/ansys/mapdl/reader/rst.py
@@ -907,7 +907,7 @@ class Result(AnsysBinary):
         if isinstance(node_components, str):
             node_components = [node_components]
 
-        mask = np.zeros(grid.n_points, np.bool)
+        mask = np.zeros(grid.n_points, np.bool_)
         for component in node_components:
             component = component.upper()
             if component not in grid.point_data:
@@ -915,7 +915,7 @@ class Result(AnsysBinary):
                     "Result file does not contain node " + 'component "%s"' % component
                 )
 
-            mask += grid.point_data[component].view(np.bool)
+            mask += grid.point_data[component].view(np.bool_)
 
         # need to extract the mesh
         cells, offset = vtk_cell_info(grid)
@@ -954,7 +954,7 @@ class Result(AnsysBinary):
         if isinstance(element_components, str):
             element_components = [element_components]
 
-        cell_mask = np.zeros(grid.n_cells, np.bool)
+        cell_mask = np.zeros(grid.n_cells, np.bool_)
         for component in element_components:
             component = component.upper()
             if component not in grid.cell_data:
@@ -962,7 +962,7 @@ class Result(AnsysBinary):
                     "Result file does not contain element "
                     + 'component "%s"' % component
                 )
-            cell_mask += grid.cell_data[component].view(np.bool)
+            cell_mask += grid.cell_data[component].view(np.bool_)
 
         if not cell_mask.any():
             raise RuntimeError("Empty component")

--- a/tests/test_binary_reader.py
+++ b/tests/test_binary_reader.py
@@ -182,7 +182,7 @@ def test_prnsol_u(mapdl, cyclic_modal, rset):
     mapdl.set(*rset)
     # verify cyclic displacements
     array = mapdl.prnsol("u").to_array()
-    ansys_nnum = array[:, 0].astype(np.int)
+    ansys_nnum = array[:, 0].astype(np.int_)
     ansys_disp = array[:, 1:-1]
 
     nnum, disp = mapdl.result.nodal_solution(rset)
@@ -207,7 +207,7 @@ def test_presol_s(mapdl, cyclic_modal, rset):
 
     # parse ansys result
     array = mapdl.presol("S").to_array()
-    ansys_enode = array[:, 0].astype(np.int)
+    ansys_enode = array[:, 0].astype(np.int_)
     ansys_element_stress = array[:, 1:]
 
     arr_sz = element_stress.shape[0]
@@ -222,7 +222,7 @@ def test_prnsol_s(mapdl, cyclic_modal, rset):
 
     # verify cyclic displacements
     array = mapdl.prnsol("s").to_array()
-    ansys_nnum = array[:, 0].astype(np.int)
+    ansys_nnum = array[:, 0].astype(np.int_)
     ansys_stress = array[:, 1:]
 
     nnum, stress = mapdl.result.nodal_stress(rset)
@@ -244,7 +244,7 @@ def test_prnsol_prin(mapdl, cyclic_modal, rset):
 
     # verify principal stress
     array = mapdl.prnsol("prin").to_array()
-    ansys_nnum = array[:, 0].astype(np.int)
+    ansys_nnum = array[:, 0].astype(np.int_)
     ansys_stress = array[:, 1:]
 
     nnum, stress = mapdl.result.principal_nodal_stress(rset)

--- a/tests/test_cyclic.py
+++ b/tests/test_cyclic.py
@@ -96,7 +96,7 @@ def test_nodal_cyclic_modal(academic_rotor, load_step, sub_step, rtype):
 
     # ANSYS will not average across geometric discontinuities, pymapdl_reader
     # always does.  These 10 nodes are along the blade/sector interface
-    dmask = np.ones(stress[0].shape[0], np.bool)
+    dmask = np.ones(stress[0].shape[0], np.bool_)
     dmask[[99, 111, 115, 116, 117, 135, 142, 146, 147, 148]] = False
 
     # large atol due to the float32 encoding of the stress
@@ -198,7 +198,7 @@ def test_element_stress_v182_non_cyclic():
         if len(line) == 201:
             ansys_element_stress.append(line)
     ansys_element_stress = np.genfromtxt(ansys_element_stress)
-    ansys_enode = ansys_element_stress[:, 0].astype(np.int)
+    ansys_enode = ansys_element_stress[:, 0].astype(np.int_)
     ansys_element_stress = ansys_element_stress[:, 1:]
 
     """
@@ -222,7 +222,7 @@ def test_nodal_stress_v182_non_cyclic():
     Generated with:
     msg = ansys.Prnsol('s').splitlines()
     array = np.genfromtxt(msg[9:])
-    ansys_nnum = array[:, 0].astype(np.int)
+    ansys_nnum = array[:, 0].astype(np.int_)
     ansys_stress = array[:, 1:]
     """
     ansys_result_file = os.path.join(cyclic_testfiles_path, "cyclic_v182.rst")


### PR DESCRIPTION
As the title.

Fix compatibility with Numpy 1.24.