### PR TITLE
docs: update contributing to ref PyMAPDL-Reader

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 Overall guidance on contributing to a PyAnsys library appears in the
 [Contributing] topic in the *PyAnsys developer's guide*. Ensure that you
 are thoroughly familiar with this guide before attempting to contribute to
-{project-name}.
+ PyMAPDL-Reader.
 
-The following contribution information is specific to {project-name}.
+The following contribution information is specific to  PyMAPDL-Reader.
 
 [Contributing]: https://dev.docs.pyansys.com/how-to/contributing.html
 


### PR DESCRIPTION
The project name was not added in place of the generic `{project-name}`