### PR TITLE
build: restrict support for building. Only from cp10-* to cp13-*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
           retention-days: 7
 
   mac_build:
-    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     name: Build wheels on MacOS
     runs-on: macos-latest
 


### PR DESCRIPTION
As the title.

Close #650 